### PR TITLE
Introduce ReceiveAuthKey (Review Branch)

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -63,7 +63,8 @@ use lightning::routing::router::{
 	InFlightHtlcs, Path, PaymentParameters, Route, RouteHop, RouteParameters, Router,
 };
 use lightning::sign::{
-	EntropySource, InMemorySigner, NodeSigner, PeerStorageKey, Recipient, SignerProvider,
+	EntropySource, InMemorySigner, NodeSigner, PeerStorageKey, ReceiveAuthKey, Recipient,
+	SignerProvider,
 };
 use lightning::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::util::config::UserConfig;
@@ -142,8 +143,8 @@ impl MessageRouter for FuzzRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _context: MessageContext, _peers: Vec<PublicKey>,
-		_secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _local_node_receive_key: ReceiveAuthKey,
+		_context: MessageContext, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		unreachable!()
 	}
@@ -345,6 +346,10 @@ impl NodeSigner for KeyProvider {
 
 	fn get_peer_storage_key(&self) -> PeerStorageKey {
 		PeerStorageKey { inner: [42; 32] }
+	}
+
+	fn get_receive_auth_key(&self) -> ReceiveAuthKey {
+		ReceiveAuthKey([41; 32])
 	}
 
 	fn sign_bolt12_invoice(

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -57,7 +57,8 @@ use lightning::routing::router::{
 };
 use lightning::routing::utxo::UtxoLookup;
 use lightning::sign::{
-	EntropySource, InMemorySigner, NodeSigner, PeerStorageKey, Recipient, SignerProvider,
+	EntropySource, InMemorySigner, NodeSigner, PeerStorageKey, ReceiveAuthKey, Recipient,
+	SignerProvider,
 };
 use lightning::types::payment::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::util::config::{ChannelConfig, UserConfig};
@@ -173,8 +174,8 @@ impl MessageRouter for FuzzRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _context: MessageContext, _peers: Vec<PublicKey>,
-		_secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _local_node_receive_key: ReceiveAuthKey,
+		_context: MessageContext, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		unreachable!()
 	}
@@ -437,6 +438,10 @@ impl NodeSigner for KeyProvider {
 
 	fn get_peer_storage_key(&self) -> PeerStorageKey {
 		PeerStorageKey { inner: [42; 32] }
+	}
+
+	fn get_receive_auth_key(&self) -> ReceiveAuthKey {
+		ReceiveAuthKey([41; 32])
 	}
 }
 

--- a/fuzz/src/onion_message.rs
+++ b/fuzz/src/onion_message.rs
@@ -24,7 +24,9 @@ use lightning::onion_message::messenger::{
 };
 use lightning::onion_message::offers::{OffersMessage, OffersMessageHandler};
 use lightning::onion_message::packet::OnionMessageContents;
-use lightning::sign::{EntropySource, NodeSigner, PeerStorageKey, Recipient, SignerProvider};
+use lightning::sign::{
+	EntropySource, NodeSigner, PeerStorageKey, ReceiveAuthKey, Recipient, SignerProvider,
+};
 use lightning::types::features::InitFeatures;
 use lightning::util::logger::Logger;
 use lightning::util::ser::{LengthReadable, Writeable, Writer};
@@ -104,8 +106,8 @@ impl MessageRouter for TestMessageRouter {
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, _recipient: PublicKey, _context: MessageContext, _peers: Vec<PublicKey>,
-		_secp_ctx: &Secp256k1<T>,
+		&self, _recipient: PublicKey, _local_node_receive_key: ReceiveAuthKey,
+		_context: MessageContext, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		unreachable!()
 	}
@@ -277,6 +279,10 @@ impl NodeSigner for KeyProvider {
 
 	fn get_peer_storage_key(&self) -> PeerStorageKey {
 		unreachable!()
+	}
+
+	fn get_receive_auth_key(&self) -> ReceiveAuthKey {
+		ReceiveAuthKey([41; 32])
 	}
 }
 

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -26,7 +26,7 @@ use crate::offers::nonce::Nonce;
 use crate::offers::offer::OfferId;
 use crate::onion_message::packet::ControlTlvs;
 use crate::routing::gossip::{NodeId, ReadOnlyNetworkGraph};
-use crate::sign::{EntropySource, NodeSigner, Recipient};
+use crate::sign::{EntropySource, NodeSigner, ReceiveAuthKey, Recipient};
 use crate::types::payment::PaymentHash;
 use crate::util::scid_utils;
 use crate::util::ser::{FixedLengthReader, LengthReadableArgs, Readable, Writeable, Writer};
@@ -94,6 +94,7 @@ impl BlindedMessagePath {
 				recipient_node_id,
 				context,
 				&blinding_secret,
+				ReceiveAuthKey([41; 32]), // TODO: Pass this in
 			)
 			.map_err(|_| ())?,
 		}))
@@ -661,18 +662,19 @@ pub(crate) const MESSAGE_PADDING_ROUND_OFF: usize = 100;
 pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[MessageForwardNode],
 	recipient_node_id: PublicKey, context: MessageContext, session_priv: &SecretKey,
+	local_node_receive_key: ReceiveAuthKey,
 ) -> Result<Vec<BlindedHop>, secp256k1::Error> {
 	let pks = intermediate_nodes
 		.iter()
-		.map(|node| node.node_id)
-		.chain(core::iter::once(recipient_node_id));
+		.map(|node| (node.node_id, None))
+		.chain(core::iter::once((recipient_node_id, Some(local_node_receive_key))));
 	let is_compact = intermediate_nodes.iter().any(|node| node.short_channel_id.is_some());
 
 	let tlvs = pks
 		.clone()
 		.skip(1) // The first node's TLVs contains the next node's pubkey
 		.zip(intermediate_nodes.iter().map(|node| node.short_channel_id))
-		.map(|(pubkey, scid)| match scid {
+		.map(|((pubkey, _), scid)| match scid {
 			Some(scid) => NextMessageHop::ShortChannelId(scid),
 			None => NextMessageHop::NodeId(pubkey),
 		})

--- a/lightning/src/blinded_path/message.rs
+++ b/lightning/src/blinded_path/message.rs
@@ -57,13 +57,13 @@ impl Readable for BlindedMessagePath {
 impl BlindedMessagePath {
 	/// Create a one-hop blinded path for a message.
 	pub fn one_hop<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
-		recipient_node_id: PublicKey, context: MessageContext, entropy_source: ES,
-		secp_ctx: &Secp256k1<T>,
+		recipient_node_id: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, entropy_source: ES, secp_ctx: &Secp256k1<T>,
 	) -> Result<Self, ()>
 	where
 		ES::Target: EntropySource,
 	{
-		Self::new(&[], recipient_node_id, context, entropy_source, secp_ctx)
+		Self::new(&[], recipient_node_id, local_node_receive_key, context, entropy_source, secp_ctx)
 	}
 
 	/// Create a path for an onion message, to be forwarded along `node_pks`. The last node
@@ -73,7 +73,8 @@ impl BlindedMessagePath {
 	//  TODO: make all payloads the same size with padding + add dummy hops
 	pub fn new<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
 		intermediate_nodes: &[MessageForwardNode], recipient_node_id: PublicKey,
-		context: MessageContext, entropy_source: ES, secp_ctx: &Secp256k1<T>,
+		local_node_receive_key: ReceiveAuthKey, context: MessageContext, entropy_source: ES,
+		secp_ctx: &Secp256k1<T>,
 	) -> Result<Self, ()>
 	where
 		ES::Target: EntropySource,
@@ -94,7 +95,7 @@ impl BlindedMessagePath {
 				recipient_node_id,
 				context,
 				&blinding_secret,
-				ReceiveAuthKey([41; 32]), // TODO: Pass this in
+				local_node_receive_key,
 			)
 			.map_err(|_| ())?,
 		}))

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -664,8 +664,10 @@ pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[PaymentForwardNode], payee_node_id: PublicKey,
 	payee_tlvs: ReceiveTlvs, session_priv: &SecretKey,
 ) -> Result<Vec<BlindedHop>, secp256k1::Error> {
-	let pks =
-		intermediate_nodes.iter().map(|node| node.node_id).chain(core::iter::once(payee_node_id));
+	let pks = intermediate_nodes
+		.iter()
+		.map(|node| (node.node_id, None))
+		.chain(core::iter::once((payee_node_id, None)));
 	let tlvs = intermediate_nodes
 		.iter()
 		.map(|node| BlindedPaymentTlvsRef::Forward(&node.tlvs))

--- a/lightning/src/blinded_path/utils.rs
+++ b/lightning/src/blinded_path/utils.rs
@@ -113,9 +113,13 @@ pub(crate) fn construct_keys_for_onion_message<'a, T, I, F>(
 where
 	T: secp256k1::Signing + secp256k1::Verification,
 	I: Iterator<Item = PublicKey>,
-	F: FnMut(PublicKey, SharedSecret, PublicKey, [u8; 32], Option<PublicKey>, Option<Vec<u8>>),
+	F: FnMut(SharedSecret, PublicKey, [u8; 32], Option<PublicKey>, Option<Vec<u8>>),
 {
-	build_keys_helper!(session_priv, secp_ctx, callback);
+	let mut callback_wrapper =
+		|_, ss, pk, encrypted_payload_rho, unblinded_hop_data, encrypted_payload| {
+			callback(ss, pk, encrypted_payload_rho, unblinded_hop_data, encrypted_payload);
+		};
+	build_keys_helper!(session_priv, secp_ctx, callback_wrapper);
 
 	for pk in unblinded_path {
 		build_keys_in_loop!(pk, false, None);

--- a/lightning/src/crypto/chacha20poly1305rfc.rs
+++ b/lightning/src/crypto/chacha20poly1305rfc.rs
@@ -10,247 +10,148 @@
 // This is a port of Andrew Moons poly1305-donna
 // https://github.com/floodyberry/poly1305-donna
 
-#[cfg(not(fuzzing))]
-mod real_chachapoly {
-	use super::super::chacha20::ChaCha20;
-	use super::super::fixed_time_eq;
-	use super::super::poly1305::Poly1305;
+use super::chacha20::ChaCha20;
+use super::fixed_time_eq;
+use super::poly1305::Poly1305;
 
-	#[derive(Clone, Copy)]
-	pub struct ChaCha20Poly1305RFC {
-		cipher: ChaCha20,
-		mac: Poly1305,
-		finished: bool,
-		data_len: usize,
-		aad_len: u64,
+pub struct ChaCha20Poly1305RFC {
+	cipher: ChaCha20,
+	mac: Poly1305,
+	finished: bool,
+	data_len: usize,
+	aad_len: u64,
+}
+
+impl ChaCha20Poly1305RFC {
+	#[inline]
+	fn pad_mac_16(mac: &mut Poly1305, len: usize) {
+		if len % 16 != 0 {
+			mac.input(&[0; 16][0..16 - (len % 16)]);
+		}
+	}
+	pub fn new(key: &[u8], nonce: &[u8], aad: &[u8]) -> ChaCha20Poly1305RFC {
+		assert!(key.len() == 16 || key.len() == 32);
+		assert!(nonce.len() == 12);
+
+		// Ehh, I'm too lazy to *also* tweak ChaCha20 to make it RFC-compliant
+		assert!(nonce[0] == 0 && nonce[1] == 0 && nonce[2] == 0 && nonce[3] == 0);
+
+		let mut cipher = ChaCha20::new(key, &nonce[4..]);
+		let mut mac_key = [0u8; 64];
+		let zero_key = [0u8; 64];
+		cipher.process(&zero_key, &mut mac_key);
+
+		#[cfg(not(fuzzing))]
+		let mut mac = Poly1305::new(&mac_key[..32]);
+		#[cfg(fuzzing)]
+		let mut mac = Poly1305::new(&key);
+		mac.input(aad);
+		ChaCha20Poly1305RFC::pad_mac_16(&mut mac, aad.len());
+
+		ChaCha20Poly1305RFC { cipher, mac, finished: false, data_len: 0, aad_len: aad.len() as u64 }
 	}
 
-	impl ChaCha20Poly1305RFC {
-		#[inline]
-		fn pad_mac_16(mac: &mut Poly1305, len: usize) {
-			if len % 16 != 0 {
-				mac.input(&[0; 16][0..16 - (len % 16)]);
-			}
-		}
-		pub fn new(key: &[u8], nonce: &[u8], aad: &[u8]) -> ChaCha20Poly1305RFC {
-			assert!(key.len() == 16 || key.len() == 32);
-			assert!(nonce.len() == 12);
+	pub fn encrypt(&mut self, input: &[u8], output: &mut [u8], out_tag: &mut [u8]) {
+		assert!(input.len() == output.len());
+		assert!(!self.finished);
+		self.cipher.process(input, output);
+		self.data_len += input.len();
+		self.mac.input(output);
+		ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
+		self.finished = true;
+		self.mac.input(&self.aad_len.to_le_bytes());
+		self.mac.input(&(self.data_len as u64).to_le_bytes());
+		out_tag.copy_from_slice(&self.mac.result());
+	}
 
-			// Ehh, I'm too lazy to *also* tweak ChaCha20 to make it RFC-compliant
-			assert!(nonce[0] == 0 && nonce[1] == 0 && nonce[2] == 0 && nonce[3] == 0);
+	pub fn encrypt_full_message_in_place(&mut self, input_output: &mut [u8], out_tag: &mut [u8]) {
+		self.encrypt_in_place(input_output);
+		self.finish_and_get_tag(out_tag);
+	}
 
-			let mut cipher = ChaCha20::new(key, &nonce[4..]);
-			let mut mac_key = [0u8; 64];
-			let zero_key = [0u8; 64];
-			cipher.process(&zero_key, &mut mac_key);
+	// Encrypt `input_output` in-place. To finish and calculate the tag, use `finish_and_get_tag`
+	// below.
+	pub(in super::super) fn encrypt_in_place(&mut self, input_output: &mut [u8]) {
+		debug_assert!(!self.finished);
+		self.cipher.process_in_place(input_output);
+		self.data_len += input_output.len();
+		self.mac.input(input_output);
+	}
 
-			let mut mac = Poly1305::new(&mac_key[..32]);
-			mac.input(aad);
-			ChaCha20Poly1305RFC::pad_mac_16(&mut mac, aad.len());
+	// If we were previously encrypting with `encrypt_in_place`, this method can be used to finish
+	// encrypting and calculate the tag.
+	pub(in super::super) fn finish_and_get_tag(&mut self, out_tag: &mut [u8]) {
+		debug_assert!(!self.finished);
+		ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
+		self.finished = true;
+		self.mac.input(&self.aad_len.to_le_bytes());
+		self.mac.input(&(self.data_len as u64).to_le_bytes());
+		out_tag.copy_from_slice(&self.mac.result());
+	}
 
-			ChaCha20Poly1305RFC {
-				cipher,
-				mac,
-				finished: false,
-				data_len: 0,
-				aad_len: aad.len() as u64,
-			}
-		}
+	/// Decrypt the `input`, checking the given `tag` prior to writing the decrypted contents
+	/// into `output`. Note that, because `output` is not touched until the `tag` is checked,
+	/// this decryption is *variable time*.
+	pub fn variable_time_decrypt(
+		&mut self, input: &[u8], output: &mut [u8], tag: &[u8],
+	) -> Result<(), ()> {
+		assert!(input.len() == output.len());
+		assert!(!self.finished);
 
-		pub fn encrypt(&mut self, input: &[u8], output: &mut [u8], out_tag: &mut [u8]) {
-			assert!(input.len() == output.len());
-			assert!(!self.finished);
+		self.finished = true;
+
+		self.mac.input(input);
+
+		self.data_len += input.len();
+		ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
+		self.mac.input(&self.aad_len.to_le_bytes());
+		self.mac.input(&(self.data_len as u64).to_le_bytes());
+
+		let calc_tag = self.mac.result();
+		if fixed_time_eq(&calc_tag, tag) {
 			self.cipher.process(input, output);
-			self.data_len += input.len();
-			self.mac.input(output);
-			ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
-			self.finished = true;
-			self.mac.input(&self.aad_len.to_le_bytes());
-			self.mac.input(&(self.data_len as u64).to_le_bytes());
-			out_tag.copy_from_slice(&self.mac.result());
-		}
-
-		pub fn encrypt_full_message_in_place(
-			&mut self, input_output: &mut [u8], out_tag: &mut [u8],
-		) {
-			self.encrypt_in_place(input_output);
-			self.finish_and_get_tag(out_tag);
-		}
-
-		// Encrypt `input_output` in-place. To finish and calculate the tag, use `finish_and_get_tag`
-		// below.
-		pub(in super::super) fn encrypt_in_place(&mut self, input_output: &mut [u8]) {
-			debug_assert!(!self.finished);
-			self.cipher.process_in_place(input_output);
-			self.data_len += input_output.len();
-			self.mac.input(input_output);
-		}
-
-		// If we were previously encrypting with `encrypt_in_place`, this method can be used to finish
-		// encrypting and calculate the tag.
-		pub(in super::super) fn finish_and_get_tag(&mut self, out_tag: &mut [u8]) {
-			debug_assert!(!self.finished);
-			ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
-			self.finished = true;
-			self.mac.input(&self.aad_len.to_le_bytes());
-			self.mac.input(&(self.data_len as u64).to_le_bytes());
-			out_tag.copy_from_slice(&self.mac.result());
-		}
-
-		/// Decrypt the `input`, checking the given `tag` prior to writing the decrypted contents
-		/// into `output`. Note that, because `output` is not touched until the `tag` is checked,
-		/// this decryption is *variable time*.
-		pub fn variable_time_decrypt(
-			&mut self, input: &[u8], output: &mut [u8], tag: &[u8],
-		) -> Result<(), ()> {
-			assert!(input.len() == output.len());
-			assert!(!self.finished);
-
-			self.finished = true;
-
-			self.mac.input(input);
-
-			self.data_len += input.len();
-			ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
-			self.mac.input(&self.aad_len.to_le_bytes());
-			self.mac.input(&(self.data_len as u64).to_le_bytes());
-
-			let calc_tag = self.mac.result();
-			if fixed_time_eq(&calc_tag, tag) {
-				self.cipher.process(input, output);
-				Ok(())
-			} else {
-				Err(())
-			}
-		}
-
-		pub fn check_decrypt_in_place(
-			&mut self, input_output: &mut [u8], tag: &[u8],
-		) -> Result<(), ()> {
-			self.decrypt_in_place(input_output);
-			if self.finish_and_check_tag(tag) {
-				Ok(())
-			} else {
-				Err(())
-			}
-		}
-
-		/// Decrypt in place, without checking the tag. Use `finish_and_check_tag` to check it
-		/// later when decryption finishes.
-		///
-		/// Should never be `pub` because the public API should always enforce tag checking.
-		pub(in super::super) fn decrypt_in_place(&mut self, input_output: &mut [u8]) {
-			debug_assert!(!self.finished);
-			self.mac.input(input_output);
-			self.data_len += input_output.len();
-			self.cipher.process_in_place(input_output);
-		}
-
-		/// If we were previously decrypting with `just_decrypt_in_place`, this method must be used
-		/// to check the tag. Returns whether or not the tag is valid.
-		pub(in super::super) fn finish_and_check_tag(&mut self, tag: &[u8]) -> bool {
-			debug_assert!(!self.finished);
-			self.finished = true;
-			ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
-			self.mac.input(&self.aad_len.to_le_bytes());
-			self.mac.input(&(self.data_len as u64).to_le_bytes());
-
-			let calc_tag = self.mac.result();
-			if fixed_time_eq(&calc_tag, tag) {
-				true
-			} else {
-				false
-			}
-		}
-	}
-}
-#[cfg(not(fuzzing))]
-pub use self::real_chachapoly::ChaCha20Poly1305RFC;
-
-#[cfg(fuzzing)]
-mod fuzzy_chachapoly {
-	#[derive(Clone, Copy)]
-	pub struct ChaCha20Poly1305RFC {
-		tag: [u8; 16],
-		finished: bool,
-	}
-	impl ChaCha20Poly1305RFC {
-		pub fn new(key: &[u8], nonce: &[u8], _aad: &[u8]) -> ChaCha20Poly1305RFC {
-			assert!(key.len() == 16 || key.len() == 32);
-			assert!(nonce.len() == 12);
-
-			// Ehh, I'm too lazy to *also* tweak ChaCha20 to make it RFC-compliant
-			assert!(nonce[0] == 0 && nonce[1] == 0 && nonce[2] == 0 && nonce[3] == 0);
-
-			let mut tag = [0; 16];
-			tag.copy_from_slice(&key[0..16]);
-
-			ChaCha20Poly1305RFC { tag, finished: false }
-		}
-
-		pub fn encrypt(&mut self, input: &[u8], output: &mut [u8], out_tag: &mut [u8]) {
-			assert!(input.len() == output.len());
-			assert!(self.finished == false);
-
-			output.copy_from_slice(&input);
-			out_tag.copy_from_slice(&self.tag);
-			self.finished = true;
-		}
-
-		pub fn encrypt_full_message_in_place(
-			&mut self, input_output: &mut [u8], out_tag: &mut [u8],
-		) {
-			self.encrypt_in_place(input_output);
-			self.finish_and_get_tag(out_tag);
-		}
-
-		pub(in super::super) fn encrypt_in_place(&mut self, _input_output: &mut [u8]) {
-			assert!(self.finished == false);
-		}
-
-		pub(in super::super) fn finish_and_get_tag(&mut self, out_tag: &mut [u8]) {
-			assert!(self.finished == false);
-			out_tag.copy_from_slice(&self.tag);
-			self.finished = true;
-		}
-
-		pub fn variable_time_decrypt(
-			&mut self, input: &[u8], output: &mut [u8], tag: &[u8],
-		) -> Result<(), ()> {
-			assert!(input.len() == output.len());
-			assert!(self.finished == false);
-
-			if tag[..] != self.tag[..] {
-				return Err(());
-			}
-			output.copy_from_slice(input);
-			self.finished = true;
 			Ok(())
+		} else {
+			Err(())
 		}
+	}
 
-		pub fn check_decrypt_in_place(
-			&mut self, input_output: &mut [u8], tag: &[u8],
-		) -> Result<(), ()> {
-			self.decrypt_in_place(input_output);
-			if self.finish_and_check_tag(tag) {
-				Ok(())
-			} else {
-				Err(())
-			}
+	pub fn check_decrypt_in_place(
+		&mut self, input_output: &mut [u8], tag: &[u8],
+	) -> Result<(), ()> {
+		self.decrypt_in_place(input_output);
+		if self.finish_and_check_tag(tag) {
+			Ok(())
+		} else {
+			Err(())
 		}
+	}
 
-		pub(in super::super) fn decrypt_in_place(&mut self, _input: &mut [u8]) {
-			assert!(self.finished == false);
-		}
+	/// Decrypt in place, without checking the tag. Use `finish_and_check_tag` to check it
+	/// later when decryption finishes.
+	///
+	/// Should never be `pub` because the public API should always enforce tag checking.
+	pub(in super::super) fn decrypt_in_place(&mut self, input_output: &mut [u8]) {
+		debug_assert!(!self.finished);
+		self.mac.input(input_output);
+		self.data_len += input_output.len();
+		self.cipher.process_in_place(input_output);
+	}
 
-		pub(in super::super) fn finish_and_check_tag(&mut self, tag: &[u8]) -> bool {
-			if tag[..] != self.tag[..] {
-				return false;
-			}
-			self.finished = true;
+	/// If we were previously decrypting with `just_decrypt_in_place`, this method must be used
+	/// to check the tag. Returns whether or not the tag is valid.
+	pub(in super::super) fn finish_and_check_tag(&mut self, tag: &[u8]) -> bool {
+		debug_assert!(!self.finished);
+		self.finished = true;
+		ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
+		self.mac.input(&self.aad_len.to_le_bytes());
+		self.mac.input(&(self.data_len as u64).to_le_bytes());
+
+		let calc_tag = self.mac.result();
+		if fixed_time_eq(&calc_tag, tag) {
 			true
+		} else {
+			false
 		}
 	}
 }
-#[cfg(fuzzing)]
-pub use self::fuzzy_chachapoly::ChaCha20Poly1305RFC;

--- a/lightning/src/crypto/chacha20poly1305rfc.rs
+++ b/lightning/src/crypto/chacha20poly1305rfc.rs
@@ -67,7 +67,7 @@ mod real_chachapoly {
 			self.finished = true;
 			self.mac.input(&self.aad_len.to_le_bytes());
 			self.mac.input(&(self.data_len as u64).to_le_bytes());
-			self.mac.raw_result(out_tag);
+			out_tag.copy_from_slice(&self.mac.result());
 		}
 
 		pub fn encrypt_full_message_in_place(
@@ -94,7 +94,7 @@ mod real_chachapoly {
 			self.finished = true;
 			self.mac.input(&self.aad_len.to_le_bytes());
 			self.mac.input(&(self.data_len as u64).to_le_bytes());
-			self.mac.raw_result(out_tag);
+			out_tag.copy_from_slice(&self.mac.result());
 		}
 
 		/// Decrypt the `input`, checking the given `tag` prior to writing the decrypted contents
@@ -115,8 +115,7 @@ mod real_chachapoly {
 			self.mac.input(&self.aad_len.to_le_bytes());
 			self.mac.input(&(self.data_len as u64).to_le_bytes());
 
-			let mut calc_tag = [0u8; 16];
-			self.mac.raw_result(&mut calc_tag);
+			let calc_tag = self.mac.result();
 			if fixed_time_eq(&calc_tag, tag) {
 				self.cipher.process(input, output);
 				Ok(())
@@ -156,8 +155,7 @@ mod real_chachapoly {
 			self.mac.input(&self.aad_len.to_le_bytes());
 			self.mac.input(&(self.data_len as u64).to_le_bytes());
 
-			let mut calc_tag = [0u8; 16];
-			self.mac.raw_result(&mut calc_tag);
+			let calc_tag = self.mac.result();
 			if fixed_time_eq(&calc_tag, tag) {
 				true
 			} else {

--- a/lightning/src/crypto/mod.rs
+++ b/lightning/src/crypto/mod.rs
@@ -1,9 +1,14 @@
 #[cfg(not(fuzzing))]
-use bitcoin::hashes::cmp::fixed_time_eq;
+pub(crate) use bitcoin::hashes::cmp::fixed_time_eq;
+
+#[cfg(fuzzing)]
+fn fixed_time_eq(a: &[u8], b: &[u8]) -> bool {
+	assert_eq!(a.len(), b.len());
+	a == b
+}
 
 pub(crate) mod chacha20;
 pub(crate) mod chacha20poly1305rfc;
-#[cfg(not(fuzzing))]
 pub(crate) mod poly1305;
 pub(crate) mod streams;
 pub(crate) mod utils;

--- a/lightning/src/crypto/poly1305.rs
+++ b/lightning/src/crypto/poly1305.rs
@@ -7,386 +7,428 @@
 // This is a port of Andrew Moons poly1305-donna
 // https://github.com/floodyberry/poly1305-donna
 
-use core::cmp::min;
+#[cfg(not(fuzzing))]
+mod poly1305 {
+	use core::cmp::min;
 
-use crate::prelude::*;
-
-#[derive(Clone, Copy)]
-pub struct Poly1305 {
-	r: [u32; 5],
-	h: [u32; 5],
-	pad: [u32; 4],
-	leftover: usize,
-	buffer: [u8; 16],
-	finalized: bool,
-}
-
-impl Poly1305 {
-	pub fn new(key: &[u8]) -> Poly1305 {
-		assert!(key.len() == 32);
-		let mut poly = Poly1305 {
-			r: [0u32; 5],
-			h: [0u32; 5],
-			pad: [0u32; 4],
-			leftover: 0,
-			buffer: [0u8; 16],
-			finalized: false,
-		};
-
-		// r &= 0xffffffc0ffffffc0ffffffc0fffffff
-		poly.r[0] = (u32::from_le_bytes(key[0..4].try_into().expect("len is 4"))) & 0x3ffffff;
-		poly.r[1] = (u32::from_le_bytes(key[3..7].try_into().expect("len is 4")) >> 2) & 0x3ffff03;
-		poly.r[2] = (u32::from_le_bytes(key[6..10].try_into().expect("len is 4")) >> 4) & 0x3ffc0ff;
-		poly.r[3] = (u32::from_le_bytes(key[9..13].try_into().expect("len is 4")) >> 6) & 0x3f03fff;
-		poly.r[4] =
-			(u32::from_le_bytes(key[12..16].try_into().expect("len is 4")) >> 8) & 0x00fffff;
-
-		poly.pad[0] = u32::from_le_bytes(key[16..20].try_into().expect("len is 4"));
-		poly.pad[1] = u32::from_le_bytes(key[20..24].try_into().expect("len is 4"));
-		poly.pad[2] = u32::from_le_bytes(key[24..28].try_into().expect("len is 4"));
-		poly.pad[3] = u32::from_le_bytes(key[28..32].try_into().expect("len is 4"));
-
-		poly
+	#[derive(Clone, Copy)]
+	pub struct Poly1305 {
+		r: [u32; 5],
+		h: [u32; 5],
+		pad: [u32; 4],
+		leftover: usize,
+		buffer: [u8; 16],
+		finalized: bool,
 	}
 
-	fn block(&mut self, m: &[u8]) {
-		let hibit: u32 = if self.finalized { 0 } else { 1 << 24 };
+	impl Poly1305 {
+		pub fn new(key: &[u8]) -> Poly1305 {
+			assert!(key.len() == 32);
+			let mut poly = Poly1305 {
+				r: [0u32; 5],
+				h: [0u32; 5],
+				pad: [0u32; 4],
+				leftover: 0,
+				buffer: [0u8; 16],
+				finalized: false,
+			};
 
-		let r0 = self.r[0];
-		let r1 = self.r[1];
-		let r2 = self.r[2];
-		let r3 = self.r[3];
-		let r4 = self.r[4];
+			// r &= 0xffffffc0ffffffc0ffffffc0fffffff
+			poly.r[0] = (u32::from_le_bytes(key[0..4].try_into().expect("len is 4"))) & 0x3ffffff;
+			poly.r[1] =
+				(u32::from_le_bytes(key[3..7].try_into().expect("len is 4")) >> 2) & 0x3ffff03;
+			poly.r[2] =
+				(u32::from_le_bytes(key[6..10].try_into().expect("len is 4")) >> 4) & 0x3ffc0ff;
+			poly.r[3] =
+				(u32::from_le_bytes(key[9..13].try_into().expect("len is 4")) >> 6) & 0x3f03fff;
+			poly.r[4] =
+				(u32::from_le_bytes(key[12..16].try_into().expect("len is 4")) >> 8) & 0x00fffff;
 
-		let s1 = r1 * 5;
-		let s2 = r2 * 5;
-		let s3 = r3 * 5;
-		let s4 = r4 * 5;
+			poly.pad[0] = u32::from_le_bytes(key[16..20].try_into().expect("len is 4"));
+			poly.pad[1] = u32::from_le_bytes(key[20..24].try_into().expect("len is 4"));
+			poly.pad[2] = u32::from_le_bytes(key[24..28].try_into().expect("len is 4"));
+			poly.pad[3] = u32::from_le_bytes(key[28..32].try_into().expect("len is 4"));
 
-		let mut h0 = self.h[0];
-		let mut h1 = self.h[1];
-		let mut h2 = self.h[2];
-		let mut h3 = self.h[3];
-		let mut h4 = self.h[4];
-
-		// h += m
-		h0 += (u32::from_le_bytes(m[0..4].try_into().expect("len is 4"))) & 0x3ffffff;
-		h1 += (u32::from_le_bytes(m[3..7].try_into().expect("len is 4")) >> 2) & 0x3ffffff;
-		h2 += (u32::from_le_bytes(m[6..10].try_into().expect("len is 4")) >> 4) & 0x3ffffff;
-		h3 += (u32::from_le_bytes(m[9..13].try_into().expect("len is 4")) >> 6) & 0x3ffffff;
-		h4 += (u32::from_le_bytes(m[12..16].try_into().expect("len is 4")) >> 8) | hibit;
-
-		// h *= r
-		let d0 = (h0 as u64 * r0 as u64)
-			+ (h1 as u64 * s4 as u64)
-			+ (h2 as u64 * s3 as u64)
-			+ (h3 as u64 * s2 as u64)
-			+ (h4 as u64 * s1 as u64);
-		let mut d1 = (h0 as u64 * r1 as u64)
-			+ (h1 as u64 * r0 as u64)
-			+ (h2 as u64 * s4 as u64)
-			+ (h3 as u64 * s3 as u64)
-			+ (h4 as u64 * s2 as u64);
-		let mut d2 = (h0 as u64 * r2 as u64)
-			+ (h1 as u64 * r1 as u64)
-			+ (h2 as u64 * r0 as u64)
-			+ (h3 as u64 * s4 as u64)
-			+ (h4 as u64 * s3 as u64);
-		let mut d3 = (h0 as u64 * r3 as u64)
-			+ (h1 as u64 * r2 as u64)
-			+ (h2 as u64 * r1 as u64)
-			+ (h3 as u64 * r0 as u64)
-			+ (h4 as u64 * s4 as u64);
-		let mut d4 = (h0 as u64 * r4 as u64)
-			+ (h1 as u64 * r3 as u64)
-			+ (h2 as u64 * r2 as u64)
-			+ (h3 as u64 * r1 as u64)
-			+ (h4 as u64 * r0 as u64);
-
-		// (partial) h %= p
-		let mut c: u32;
-		c = (d0 >> 26) as u32;
-		h0 = d0 as u32 & 0x3ffffff;
-		d1 += c as u64;
-		c = (d1 >> 26) as u32;
-		h1 = d1 as u32 & 0x3ffffff;
-		d2 += c as u64;
-		c = (d2 >> 26) as u32;
-		h2 = d2 as u32 & 0x3ffffff;
-		d3 += c as u64;
-		c = (d3 >> 26) as u32;
-		h3 = d3 as u32 & 0x3ffffff;
-		d4 += c as u64;
-		c = (d4 >> 26) as u32;
-		h4 = d4 as u32 & 0x3ffffff;
-		h0 += c * 5;
-		c = h0 >> 26;
-		h0 &= 0x3ffffff;
-		h1 += c;
-
-		self.h[0] = h0;
-		self.h[1] = h1;
-		self.h[2] = h2;
-		self.h[3] = h3;
-		self.h[4] = h4;
-	}
-
-	pub fn finish(&mut self) {
-		if self.leftover > 0 {
-			self.buffer[self.leftover] = 1;
-			for i in self.leftover + 1..16 {
-				self.buffer[i] = 0;
-			}
-			self.finalized = true;
-			let tmp = self.buffer;
-			self.block(&tmp);
+			poly
 		}
 
-		// fully carry h
-		let mut h0 = self.h[0];
-		let mut h1 = self.h[1];
-		let mut h2 = self.h[2];
-		let mut h3 = self.h[3];
-		let mut h4 = self.h[4];
+		fn block(&mut self, m: &[u8]) {
+			let hibit: u32 = if self.finalized { 0 } else { 1 << 24 };
 
-		let mut c: u32;
-		c = h1 >> 26;
-		h1 &= 0x3ffffff;
-		h2 += c;
-		c = h2 >> 26;
-		h2 &= 0x3ffffff;
-		h3 += c;
-		c = h3 >> 26;
-		h3 &= 0x3ffffff;
-		h4 += c;
-		c = h4 >> 26;
-		h4 &= 0x3ffffff;
-		h0 += c * 5;
-		c = h0 >> 26;
-		h0 &= 0x3ffffff;
-		h1 += c;
+			let r0 = self.r[0];
+			let r1 = self.r[1];
+			let r2 = self.r[2];
+			let r3 = self.r[3];
+			let r4 = self.r[4];
 
-		// compute h + -p
-		let mut g0 = h0.wrapping_add(5);
-		c = g0 >> 26;
-		g0 &= 0x3ffffff;
-		let mut g1 = h1.wrapping_add(c);
-		c = g1 >> 26;
-		g1 &= 0x3ffffff;
-		let mut g2 = h2.wrapping_add(c);
-		c = g2 >> 26;
-		g2 &= 0x3ffffff;
-		let mut g3 = h3.wrapping_add(c);
-		c = g3 >> 26;
-		g3 &= 0x3ffffff;
-		let mut g4 = h4.wrapping_add(c).wrapping_sub(1 << 26);
+			let s1 = r1 * 5;
+			let s2 = r2 * 5;
+			let s3 = r3 * 5;
+			let s4 = r4 * 5;
 
-		// select h if h < p, or h + -p if h >= p
-		let mut mask = (g4 >> (32 - 1)).wrapping_sub(1);
-		g0 &= mask;
-		g1 &= mask;
-		g2 &= mask;
-		g3 &= mask;
-		g4 &= mask;
-		mask = !mask;
-		h0 = (h0 & mask) | g0;
-		h1 = (h1 & mask) | g1;
-		h2 = (h2 & mask) | g2;
-		h3 = (h3 & mask) | g3;
-		h4 = (h4 & mask) | g4;
+			let mut h0 = self.h[0];
+			let mut h1 = self.h[1];
+			let mut h2 = self.h[2];
+			let mut h3 = self.h[3];
+			let mut h4 = self.h[4];
 
-		// h = h % (2^128)
-		h0 = ((h0) | (h1 << 26)) & 0xffffffff;
-		h1 = ((h1 >> 6) | (h2 << 20)) & 0xffffffff;
-		h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
-		h3 = ((h3 >> 18) | (h4 << 8)) & 0xffffffff;
+			// h += m
+			h0 += (u32::from_le_bytes(m[0..4].try_into().expect("len is 4"))) & 0x3ffffff;
+			h1 += (u32::from_le_bytes(m[3..7].try_into().expect("len is 4")) >> 2) & 0x3ffffff;
+			h2 += (u32::from_le_bytes(m[6..10].try_into().expect("len is 4")) >> 4) & 0x3ffffff;
+			h3 += (u32::from_le_bytes(m[9..13].try_into().expect("len is 4")) >> 6) & 0x3ffffff;
+			h4 += (u32::from_le_bytes(m[12..16].try_into().expect("len is 4")) >> 8) | hibit;
 
-		// h = mac = (h + pad) % (2^128)
-		let mut f: u64;
-		f = h0 as u64 + self.pad[0] as u64;
-		h0 = f as u32;
-		f = h1 as u64 + self.pad[1] as u64 + (f >> 32);
-		h1 = f as u32;
-		f = h2 as u64 + self.pad[2] as u64 + (f >> 32);
-		h2 = f as u32;
-		f = h3 as u64 + self.pad[3] as u64 + (f >> 32);
-		h3 = f as u32;
+			// h *= r
+			let d0 = (h0 as u64 * r0 as u64)
+				+ (h1 as u64 * s4 as u64)
+				+ (h2 as u64 * s3 as u64)
+				+ (h3 as u64 * s2 as u64)
+				+ (h4 as u64 * s1 as u64);
+			let mut d1 = (h0 as u64 * r1 as u64)
+				+ (h1 as u64 * r0 as u64)
+				+ (h2 as u64 * s4 as u64)
+				+ (h3 as u64 * s3 as u64)
+				+ (h4 as u64 * s2 as u64);
+			let mut d2 = (h0 as u64 * r2 as u64)
+				+ (h1 as u64 * r1 as u64)
+				+ (h2 as u64 * r0 as u64)
+				+ (h3 as u64 * s4 as u64)
+				+ (h4 as u64 * s3 as u64);
+			let mut d3 = (h0 as u64 * r3 as u64)
+				+ (h1 as u64 * r2 as u64)
+				+ (h2 as u64 * r1 as u64)
+				+ (h3 as u64 * r0 as u64)
+				+ (h4 as u64 * s4 as u64);
+			let mut d4 = (h0 as u64 * r4 as u64)
+				+ (h1 as u64 * r3 as u64)
+				+ (h2 as u64 * r2 as u64)
+				+ (h3 as u64 * r1 as u64)
+				+ (h4 as u64 * r0 as u64);
 
-		self.h[0] = h0;
-		self.h[1] = h1;
-		self.h[2] = h2;
-		self.h[3] = h3;
-	}
+			// (partial) h %= p
+			let mut c: u32;
+			c = (d0 >> 26) as u32;
+			h0 = d0 as u32 & 0x3ffffff;
+			d1 += c as u64;
+			c = (d1 >> 26) as u32;
+			h1 = d1 as u32 & 0x3ffffff;
+			d2 += c as u64;
+			c = (d2 >> 26) as u32;
+			h2 = d2 as u32 & 0x3ffffff;
+			d3 += c as u64;
+			c = (d3 >> 26) as u32;
+			h3 = d3 as u32 & 0x3ffffff;
+			d4 += c as u64;
+			c = (d4 >> 26) as u32;
+			h4 = d4 as u32 & 0x3ffffff;
+			h0 += c * 5;
+			c = h0 >> 26;
+			h0 &= 0x3ffffff;
+			h1 += c;
 
-	pub fn input(&mut self, data: &[u8]) {
-		assert!(!self.finalized);
-		let mut m = data;
+			self.h[0] = h0;
+			self.h[1] = h1;
+			self.h[2] = h2;
+			self.h[3] = h3;
+			self.h[4] = h4;
+		}
 
-		if self.leftover > 0 {
-			let want = min(16 - self.leftover, m.len());
-			for i in 0..want {
-				self.buffer[self.leftover + i] = m[i];
-			}
-			m = &m[want..];
-			self.leftover += want;
-
-			if self.leftover < 16 {
-				return;
+		pub fn finish(&mut self) {
+			if self.leftover > 0 {
+				self.buffer[self.leftover] = 1;
+				for i in self.leftover + 1..16 {
+					self.buffer[i] = 0;
+				}
+				self.finalized = true;
+				let tmp = self.buffer;
+				self.block(&tmp);
 			}
 
-			// self.block(self.buffer[..]);
-			let tmp = self.buffer;
-			self.block(&tmp);
+			// fully carry h
+			let mut h0 = self.h[0];
+			let mut h1 = self.h[1];
+			let mut h2 = self.h[2];
+			let mut h3 = self.h[3];
+			let mut h4 = self.h[4];
 
-			self.leftover = 0;
+			let mut c: u32;
+			c = h1 >> 26;
+			h1 &= 0x3ffffff;
+			h2 += c;
+			c = h2 >> 26;
+			h2 &= 0x3ffffff;
+			h3 += c;
+			c = h3 >> 26;
+			h3 &= 0x3ffffff;
+			h4 += c;
+			c = h4 >> 26;
+			h4 &= 0x3ffffff;
+			h0 += c * 5;
+			c = h0 >> 26;
+			h0 &= 0x3ffffff;
+			h1 += c;
+
+			// compute h + -p
+			let mut g0 = h0.wrapping_add(5);
+			c = g0 >> 26;
+			g0 &= 0x3ffffff;
+			let mut g1 = h1.wrapping_add(c);
+			c = g1 >> 26;
+			g1 &= 0x3ffffff;
+			let mut g2 = h2.wrapping_add(c);
+			c = g2 >> 26;
+			g2 &= 0x3ffffff;
+			let mut g3 = h3.wrapping_add(c);
+			c = g3 >> 26;
+			g3 &= 0x3ffffff;
+			let mut g4 = h4.wrapping_add(c).wrapping_sub(1 << 26);
+
+			// select h if h < p, or h + -p if h >= p
+			let mut mask = (g4 >> (32 - 1)).wrapping_sub(1);
+			g0 &= mask;
+			g1 &= mask;
+			g2 &= mask;
+			g3 &= mask;
+			g4 &= mask;
+			mask = !mask;
+			h0 = (h0 & mask) | g0;
+			h1 = (h1 & mask) | g1;
+			h2 = (h2 & mask) | g2;
+			h3 = (h3 & mask) | g3;
+			h4 = (h4 & mask) | g4;
+
+			// h = h % (2^128)
+			h0 = ((h0) | (h1 << 26)) & 0xffffffff;
+			h1 = ((h1 >> 6) | (h2 << 20)) & 0xffffffff;
+			h2 = ((h2 >> 12) | (h3 << 14)) & 0xffffffff;
+			h3 = ((h3 >> 18) | (h4 << 8)) & 0xffffffff;
+
+			// h = mac = (h + pad) % (2^128)
+			let mut f: u64;
+			f = h0 as u64 + self.pad[0] as u64;
+			h0 = f as u32;
+			f = h1 as u64 + self.pad[1] as u64 + (f >> 32);
+			h1 = f as u32;
+			f = h2 as u64 + self.pad[2] as u64 + (f >> 32);
+			h2 = f as u32;
+			f = h3 as u64 + self.pad[3] as u64 + (f >> 32);
+			h3 = f as u32;
+
+			self.h[0] = h0;
+			self.h[1] = h1;
+			self.h[2] = h2;
+			self.h[3] = h3;
 		}
 
-		while m.len() >= 16 {
-			self.block(&m[0..16]);
-			m = &m[16..];
+		pub fn input(&mut self, data: &[u8]) {
+			assert!(!self.finalized);
+			let mut m = data;
+
+			if self.leftover > 0 {
+				let want = min(16 - self.leftover, m.len());
+				for i in 0..want {
+					self.buffer[self.leftover + i] = m[i];
+				}
+				m = &m[want..];
+				self.leftover += want;
+
+				if self.leftover < 16 {
+					return;
+				}
+
+				// self.block(self.buffer[..]);
+				let tmp = self.buffer;
+				self.block(&tmp);
+
+				self.leftover = 0;
+			}
+
+			while m.len() >= 16 {
+				self.block(&m[0..16]);
+				m = &m[16..];
+			}
+
+			for i in 0..m.len() {
+				self.buffer[i] = m[i];
+			}
+			self.leftover = m.len();
 		}
 
-		for i in 0..m.len() {
-			self.buffer[i] = m[i];
+		pub fn result(&mut self) -> [u8; 16] {
+			if !self.finalized {
+				self.finish();
+			}
+			let mut output = [0; 16];
+			output[0..4].copy_from_slice(&self.h[0].to_le_bytes());
+			output[4..8].copy_from_slice(&self.h[1].to_le_bytes());
+			output[8..12].copy_from_slice(&self.h[2].to_le_bytes());
+			output[12..16].copy_from_slice(&self.h[3].to_le_bytes());
+			output
 		}
-		self.leftover = m.len();
 	}
 
-	pub fn result(&mut self) -> [u8; 16] {
-		if !self.finalized {
-			self.finish();
+	#[cfg(test)]
+	mod test {
+		use core::iter::repeat;
+
+		use super::Poly1305;
+
+		fn poly1305(key: &[u8], msg: &[u8], mac: &mut [u8; 16]) {
+			let mut poly = Poly1305::new(key);
+			poly.input(msg);
+			*mac = poly.result();
 		}
-		let mut output = [0; 16];
-		output[0..4].copy_from_slice(&self.h[0].to_le_bytes());
-		output[4..8].copy_from_slice(&self.h[1].to_le_bytes());
-		output[8..12].copy_from_slice(&self.h[2].to_le_bytes());
-		output[12..16].copy_from_slice(&self.h[3].to_le_bytes());
-		output
-	}
-}
 
-#[cfg(test)]
-mod test {
-	use core::iter::repeat;
+		#[test]
+		fn test_nacl_vector() {
+			let key = [
+				0xee, 0xa6, 0xa7, 0x25, 0x1c, 0x1e, 0x72, 0x91, 0x6d, 0x11, 0xc2, 0xcb, 0x21, 0x4d,
+				0x3c, 0x25, 0x25, 0x39, 0x12, 0x1d, 0x8e, 0x23, 0x4e, 0x65, 0x2d, 0x65, 0x1f, 0xa4,
+				0xc8, 0xcf, 0xf8, 0x80,
+			];
 
-	use super::Poly1305;
+			let msg = [
+				0x8e, 0x99, 0x3b, 0x9f, 0x48, 0x68, 0x12, 0x73, 0xc2, 0x96, 0x50, 0xba, 0x32, 0xfc,
+				0x76, 0xce, 0x48, 0x33, 0x2e, 0xa7, 0x16, 0x4d, 0x96, 0xa4, 0x47, 0x6f, 0xb8, 0xc5,
+				0x31, 0xa1, 0x18, 0x6a, 0xc0, 0xdf, 0xc1, 0x7c, 0x98, 0xdc, 0xe8, 0x7b, 0x4d, 0xa7,
+				0xf0, 0x11, 0xec, 0x48, 0xc9, 0x72, 0x71, 0xd2, 0xc2, 0x0f, 0x9b, 0x92, 0x8f, 0xe2,
+				0x27, 0x0d, 0x6f, 0xb8, 0x63, 0xd5, 0x17, 0x38, 0xb4, 0x8e, 0xee, 0xe3, 0x14, 0xa7,
+				0xcc, 0x8a, 0xb9, 0x32, 0x16, 0x45, 0x48, 0xe5, 0x26, 0xae, 0x90, 0x22, 0x43, 0x68,
+				0x51, 0x7a, 0xcf, 0xea, 0xbd, 0x6b, 0xb3, 0x73, 0x2b, 0xc0, 0xe9, 0xda, 0x99, 0x83,
+				0x2b, 0x61, 0xca, 0x01, 0xb6, 0xde, 0x56, 0x24, 0x4a, 0x9e, 0x88, 0xd5, 0xf9, 0xb3,
+				0x79, 0x73, 0xf6, 0x22, 0xa4, 0x3d, 0x14, 0xa6, 0x59, 0x9b, 0x1f, 0x65, 0x4c, 0xb4,
+				0x5a, 0x74, 0xe3, 0x55, 0xa5,
+			];
 
-	fn poly1305(key: &[u8], msg: &[u8], mac: &mut [u8; 16]) {
-		let mut poly = Poly1305::new(key);
-		poly.input(msg);
-		*mac = poly.result();
-	}
+			let expected = [
+				0xf3, 0xff, 0xc7, 0x70, 0x3f, 0x94, 0x00, 0xe5, 0x2a, 0x7d, 0xfb, 0x4b, 0x3d, 0x33,
+				0x05, 0xd9,
+			];
 
-	#[test]
-	fn test_nacl_vector() {
-		let key = [
-			0xee, 0xa6, 0xa7, 0x25, 0x1c, 0x1e, 0x72, 0x91, 0x6d, 0x11, 0xc2, 0xcb, 0x21, 0x4d,
-			0x3c, 0x25, 0x25, 0x39, 0x12, 0x1d, 0x8e, 0x23, 0x4e, 0x65, 0x2d, 0x65, 0x1f, 0xa4,
-			0xc8, 0xcf, 0xf8, 0x80,
-		];
-
-		let msg = [
-			0x8e, 0x99, 0x3b, 0x9f, 0x48, 0x68, 0x12, 0x73, 0xc2, 0x96, 0x50, 0xba, 0x32, 0xfc,
-			0x76, 0xce, 0x48, 0x33, 0x2e, 0xa7, 0x16, 0x4d, 0x96, 0xa4, 0x47, 0x6f, 0xb8, 0xc5,
-			0x31, 0xa1, 0x18, 0x6a, 0xc0, 0xdf, 0xc1, 0x7c, 0x98, 0xdc, 0xe8, 0x7b, 0x4d, 0xa7,
-			0xf0, 0x11, 0xec, 0x48, 0xc9, 0x72, 0x71, 0xd2, 0xc2, 0x0f, 0x9b, 0x92, 0x8f, 0xe2,
-			0x27, 0x0d, 0x6f, 0xb8, 0x63, 0xd5, 0x17, 0x38, 0xb4, 0x8e, 0xee, 0xe3, 0x14, 0xa7,
-			0xcc, 0x8a, 0xb9, 0x32, 0x16, 0x45, 0x48, 0xe5, 0x26, 0xae, 0x90, 0x22, 0x43, 0x68,
-			0x51, 0x7a, 0xcf, 0xea, 0xbd, 0x6b, 0xb3, 0x73, 0x2b, 0xc0, 0xe9, 0xda, 0x99, 0x83,
-			0x2b, 0x61, 0xca, 0x01, 0xb6, 0xde, 0x56, 0x24, 0x4a, 0x9e, 0x88, 0xd5, 0xf9, 0xb3,
-			0x79, 0x73, 0xf6, 0x22, 0xa4, 0x3d, 0x14, 0xa6, 0x59, 0x9b, 0x1f, 0x65, 0x4c, 0xb4,
-			0x5a, 0x74, 0xe3, 0x55, 0xa5,
-		];
-
-		let expected = [
-			0xf3, 0xff, 0xc7, 0x70, 0x3f, 0x94, 0x00, 0xe5, 0x2a, 0x7d, 0xfb, 0x4b, 0x3d, 0x33,
-			0x05, 0xd9,
-		];
-
-		let mut mac = [0u8; 16];
-		poly1305(&key, &msg, &mut mac);
-		assert_eq!(&mac[..], &expected[..]);
-
-		let mut poly = Poly1305::new(&key);
-		poly.input(&msg[0..32]);
-		poly.input(&msg[32..96]);
-		poly.input(&msg[96..112]);
-		poly.input(&msg[112..120]);
-		poly.input(&msg[120..124]);
-		poly.input(&msg[124..126]);
-		poly.input(&msg[126..127]);
-		poly.input(&msg[127..128]);
-		poly.input(&msg[128..129]);
-		poly.input(&msg[129..130]);
-		poly.input(&msg[130..131]);
-		let mac = poly.result();
-		assert_eq!(&mac[..], &expected[..]);
-	}
-
-	#[test]
-	fn donna_self_test() {
-		let wrap_key = [
-			0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00,
-		];
-
-		let wrap_msg = [
-			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-			0xff, 0xff,
-		];
-
-		let wrap_mac = [
-			0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00,
-		];
-
-		let mut mac = [0u8; 16];
-		poly1305(&wrap_key, &wrap_msg, &mut mac);
-		assert_eq!(&mac[..], &wrap_mac[..]);
-
-		let total_key = [
-			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9,
-			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-			0x00, 0x00, 0x00, 0x00,
-		];
-
-		let total_mac = [
-			0x64, 0xaf, 0xe2, 0xe8, 0xd6, 0xad, 0x7b, 0xbd, 0xd2, 0x87, 0xf9, 0x7c, 0x44, 0x62,
-			0x3d, 0x39,
-		];
-
-		let mut tpoly = Poly1305::new(&total_key);
-		for i in 0..256 {
-			let key: Vec<u8> = repeat(i as u8).take(32).collect();
-			let msg: Vec<u8> = repeat(i as u8).take(256).collect();
 			let mut mac = [0u8; 16];
-			poly1305(&key[..], &msg[0..i], &mut mac);
-			tpoly.input(&mac);
+			poly1305(&key, &msg, &mut mac);
+			assert_eq!(&mac[..], &expected[..]);
+
+			let mut poly = Poly1305::new(&key);
+			poly.input(&msg[0..32]);
+			poly.input(&msg[32..96]);
+			poly.input(&msg[96..112]);
+			poly.input(&msg[112..120]);
+			poly.input(&msg[120..124]);
+			poly.input(&msg[124..126]);
+			poly.input(&msg[126..127]);
+			poly.input(&msg[127..128]);
+			poly.input(&msg[128..129]);
+			poly.input(&msg[129..130]);
+			poly.input(&msg[130..131]);
+			let mac = poly.result();
+			assert_eq!(&mac[..], &expected[..]);
 		}
-		let mac = tpoly.result();
-		assert_eq!(&mac[..], &total_mac[..]);
-	}
 
-	#[test]
-	fn test_tls_vectors() {
-		// from http://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-04
-		let key = b"this is 32-byte key for Poly1305";
-		let msg = [0u8; 32];
-		let expected = [
-			0x49, 0xec, 0x78, 0x09, 0x0e, 0x48, 0x1e, 0xc6, 0xc2, 0x6b, 0x33, 0xb9, 0x1c, 0xcc,
-			0x03, 0x07,
-		];
-		let mut mac = [0u8; 16];
-		poly1305(key, &msg, &mut mac);
-		assert_eq!(&mac[..], &expected[..]);
+		#[test]
+		fn donna_self_test() {
+			let wrap_key = [
+				0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+			];
 
-		let msg = b"Hello world!";
-		let expected = [
-			0xa6, 0xf7, 0x45, 0x00, 0x8f, 0x81, 0xc9, 0x16, 0xa2, 0x0d, 0xcc, 0x74, 0xee, 0xf2,
-			0xb2, 0xf0,
-		];
-		poly1305(key, msg, &mut mac);
-		assert_eq!(&mac[..], &expected[..]);
+			let wrap_msg = [
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0xff, 0xff,
+			];
+
+			let wrap_mac = [
+				0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00,
+			];
+
+			let mut mac = [0u8; 16];
+			poly1305(&wrap_key, &wrap_msg, &mut mac);
+			assert_eq!(&mac[..], &wrap_mac[..]);
+
+			let total_key = [
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9,
+				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+				0x00, 0x00, 0x00, 0x00,
+			];
+
+			let total_mac = [
+				0x64, 0xaf, 0xe2, 0xe8, 0xd6, 0xad, 0x7b, 0xbd, 0xd2, 0x87, 0xf9, 0x7c, 0x44, 0x62,
+				0x3d, 0x39,
+			];
+
+			let mut tpoly = Poly1305::new(&total_key);
+			for i in 0..256 {
+				let key: Vec<u8> = repeat(i as u8).take(32).collect();
+				let msg: Vec<u8> = repeat(i as u8).take(256).collect();
+				let mut mac = [0u8; 16];
+				poly1305(&key[..], &msg[0..i], &mut mac);
+				tpoly.input(&mac);
+			}
+			let mac = tpoly.result();
+			assert_eq!(&mac[..], &total_mac[..]);
+		}
+
+		#[test]
+		fn test_tls_vectors() {
+			// from http://tools.ietf.org/html/draft-agl-tls-chacha20poly1305-04
+			let key = b"this is 32-byte key for Poly1305";
+			let msg = [0u8; 32];
+			let expected = [
+				0x49, 0xec, 0x78, 0x09, 0x0e, 0x48, 0x1e, 0xc6, 0xc2, 0x6b, 0x33, 0xb9, 0x1c, 0xcc,
+				0x03, 0x07,
+			];
+			let mut mac = [0u8; 16];
+			poly1305(key, &msg, &mut mac);
+			assert_eq!(&mac[..], &expected[..]);
+
+			let msg = b"Hello world!";
+			let expected = [
+				0xa6, 0xf7, 0x45, 0x00, 0x8f, 0x81, 0xc9, 0x16, 0xa2, 0x0d, 0xcc, 0x74, 0xee, 0xf2,
+				0xb2, 0xf0,
+			];
+			poly1305(key, msg, &mut mac);
+			assert_eq!(&mac[..], &expected[..]);
+		}
 	}
 }
+#[cfg(not(fuzzing))]
+pub use poly1305::*;
+
+#[cfg(fuzzing)]
+mod fuzzy_poly1305 {
+	#[derive(Clone, Copy)]
+	pub struct Poly1305 {
+		tag: [u8; 16],
+		finalized: bool,
+	}
+
+	impl Poly1305 {
+		pub fn new(key: &[u8]) -> Poly1305 {
+			assert_eq!(key.len(), 32);
+			let mut poly = Poly1305 { tag: [0; 16], finalized: false };
+			poly.tag.copy_from_slice(&key[..16]);
+
+			poly
+		}
+
+		pub fn finish(&mut self) {
+			self.finalized = true;
+		}
+
+		pub fn input(&mut self, _data: &[u8]) {
+			assert!(!self.finalized);
+		}
+
+		pub fn result(&mut self) -> [u8; 16] {
+			if !self.finalized {
+				self.finish();
+			}
+			self.tag
+		}
+	}
+}
+#[cfg(fuzzing)]
+pub use fuzzy_poly1305::*;

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -247,6 +247,7 @@ fn create_static_invoice<T: secp256k1::Signing + secp256k1::Verification>(
 		.message_router
 		.create_blinded_paths(
 			always_online_counterparty.node.get_our_node_id(),
+			always_online_counterparty.keys_manager.get_receive_auth_key(),
 			MessageContext::Offers(OffersContext::InvoiceRequest { nonce: Nonce([42; 16]) }),
 			Vec::new(),
 			&secp_ctx,
@@ -383,6 +384,7 @@ fn static_invoice_unknown_required_features() {
 		.message_router
 		.create_blinded_paths(
 			nodes[1].node.get_our_node_id(),
+			nodes[1].keys_manager.get_receive_auth_key(),
 			MessageContext::Offers(OffersContext::InvoiceRequest { nonce: Nonce([42; 16]) }),
 			Vec::new(),
 			&secp_ctx,
@@ -1023,6 +1025,7 @@ fn invalid_async_receive_with_retry<F1, F2>(
 		.message_router
 		.create_blinded_paths(
 			nodes[1].node.get_our_node_id(),
+			nodes[1].keys_manager.get_receive_auth_key(),
 			MessageContext::Offers(OffersContext::InvoiceRequest { nonce: Nonce([42; 16]) }),
 			Vec::new(),
 			&secp_ctx,

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -36,7 +36,7 @@ use crate::offers::invoice::UnsignedBolt12Invoice;
 use crate::offers::nonce::Nonce;
 use crate::prelude::*;
 use crate::routing::router::{BlindedTail, Path, Payee, PaymentParameters, RouteHop, RouteParameters, TrampolineHop};
-use crate::sign::{NodeSigner, PeerStorageKey, Recipient};
+use crate::sign::{NodeSigner, PeerStorageKey, ReceiveAuthKey, Recipient};
 use crate::util::config::UserConfig;
 use crate::util::ser::{WithoutLength, Writeable};
 use crate::util::test_utils;
@@ -1638,6 +1638,7 @@ fn route_blinding_spec_test_vector() {
 			&self, _invoice: &RawBolt11Invoice, _recipient: Recipient,
 		) -> Result<RecoverableSignature, ()> { unreachable!() }
 		fn get_peer_storage_key(&self) -> PeerStorageKey { unreachable!() }
+		fn get_receive_auth_key(&self) -> ReceiveAuthKey { unreachable!() }
 		fn sign_bolt12_invoice(
 			&self, _invoice: &UnsignedBolt12Invoice,
 		) -> Result<schnorr::Signature, ()> { unreachable!() }
@@ -1948,6 +1949,7 @@ fn test_trampoline_inbound_payment_decoding() {
 			&self, _invoice: &RawBolt11Invoice, _recipient: Recipient,
 		) -> Result<RecoverableSignature, ()> { unreachable!() }
 		fn get_peer_storage_key(&self) -> PeerStorageKey { unreachable!() }
+		fn get_receive_auth_key(&self) -> ReceiveAuthKey { unreachable!() }
 		fn sign_bolt12_invoice(
 			&self, _invoice: &UnsignedBolt12Invoice,
 		) -> Result<schnorr::Signature, ()> { unreachable!() }

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -1556,17 +1556,23 @@ fn route_blinding_spec_test_vector() {
 	let blinding_override = PublicKey::from_secret_key(&secp_ctx, &dave_eve_session_priv);
 	assert_eq!(blinding_override, pubkey_from_hex("031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"));
 	// Can't use the public API here as the encrypted payloads contain unknown TLVs.
-	let path = [(dave_node_id, WithoutLength(&dave_unblinded_tlvs)), (eve_node_id, WithoutLength(&eve_unblinded_tlvs))];
+	let path = [
+		((dave_node_id, None), WithoutLength(&dave_unblinded_tlvs)),
+		((eve_node_id, None), WithoutLength(&eve_unblinded_tlvs)),
+	];
 	let mut dave_eve_blinded_hops = blinded_path::utils::construct_blinded_hops(
-		&secp_ctx, path.into_iter(), &dave_eve_session_priv
+		&secp_ctx, path.into_iter(), &dave_eve_session_priv,
 	).unwrap();
 
 	// Concatenate an additional Bob -> Carol blinded path to the Eve -> Dave blinded path.
 	let bob_carol_session_priv = secret_from_hex("0202020202020202020202020202020202020202020202020202020202020202");
 	let bob_blinding_point = PublicKey::from_secret_key(&secp_ctx, &bob_carol_session_priv);
-	let path = [(bob_node_id, WithoutLength(&bob_unblinded_tlvs)), (carol_node_id, WithoutLength(&carol_unblinded_tlvs))];
+	let path = [
+		((bob_node_id, None), WithoutLength(&bob_unblinded_tlvs)),
+		((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs)),
+	];
 	let bob_carol_blinded_hops = blinded_path::utils::construct_blinded_hops(
-		&secp_ctx, path.into_iter(), &bob_carol_session_priv
+		&secp_ctx, path.into_iter(), &bob_carol_session_priv,
 	).unwrap();
 
 	let mut blinded_hops = bob_carol_blinded_hops;
@@ -2026,9 +2032,9 @@ fn do_test_trampoline_single_hop_receive(success: bool) {
 		let payee_tlvs = payee_tlvs.authenticate(nonce, &expanded_key);
 		let carol_unblinded_tlvs = payee_tlvs.encode();
 
-		let path = [(carol_node_id, WithoutLength(&carol_unblinded_tlvs))];
+		let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
 		blinded_path::utils::construct_blinded_hops(
-			&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv
+			&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
 		).unwrap()
 	} else {
 		let payee_tlvs = blinded_path::payment::TrampolineForwardTlvs {
@@ -2047,9 +2053,9 @@ fn do_test_trampoline_single_hop_receive(success: bool) {
 		};
 
 		let carol_unblinded_tlvs = payee_tlvs.encode();
-		let path = [(carol_node_id, WithoutLength(&carol_unblinded_tlvs))];
+		let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
 		blinded_path::utils::construct_blinded_hops(
-			&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv
+			&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
 		).unwrap()
 	};
 
@@ -2249,11 +2255,11 @@ fn test_trampoline_unblinded_receive() {
 	};
 
 	let carol_unblinded_tlvs = payee_tlvs.encode();
-	let path = [(carol_node_id, WithoutLength(&carol_unblinded_tlvs))];
+	let path = [((carol_node_id, None), WithoutLength(&carol_unblinded_tlvs))];
 	let carol_alice_trampoline_session_priv = secret_from_hex("a0f4b8d7b6c2d0ffdfaf718f76e9decaef4d9fb38a8c4addb95c4007cc3eee03");
 	let carol_blinding_point = PublicKey::from_secret_key(&secp_ctx, &carol_alice_trampoline_session_priv);
 	let carol_blinded_hops = blinded_path::utils::construct_blinded_hops(
-		&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv
+		&secp_ctx, path.into_iter(), &carol_alice_trampoline_session_priv,
 	).unwrap();
 
 	let route = Route {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -547,24 +547,6 @@ pub trait Verification {
 	) -> Result<(), ()>;
 }
 
-impl Verification for PaymentHash {
-	/// Constructs an HMAC to include in [`OffersContext::InboundPayment`] for the payment hash
-	/// along with the given [`Nonce`].
-	fn hmac_for_offer_payment(
-		&self, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
-	) -> Hmac<Sha256> {
-		signer::hmac_for_payment_hash(*self, nonce, expanded_key)
-	}
-
-	/// Authenticates the payment id using an HMAC and a [`Nonce`] taken from an
-	/// [`OffersContext::InboundPayment`].
-	fn verify_for_offer_payment(
-		&self, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
-	) -> Result<(), ()> {
-		signer::verify_payment_hash(*self, hmac, nonce, expanded_key)
-	}
-}
-
 impl Verification for UnauthenticatedReceiveTlvs {
 	fn hmac_for_offer_payment(
 		&self, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
@@ -589,42 +571,6 @@ pub struct PaymentId(pub [u8; Self::LENGTH]);
 impl PaymentId {
 	/// Number of bytes in the id.
 	pub const LENGTH: usize = 32;
-
-	/// Constructs an HMAC to include in [`AsyncPaymentsContext::OutboundPayment`] for the payment id
-	/// along with the given [`Nonce`].
-	#[cfg(async_payments)]
-	pub fn hmac_for_async_payment(
-		&self, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
-	) -> Hmac<Sha256> {
-		signer::hmac_for_async_payment_id(*self, nonce, expanded_key)
-	}
-
-	/// Authenticates the payment id using an HMAC and a [`Nonce`] taken from an
-	/// [`AsyncPaymentsContext::OutboundPayment`].
-	#[cfg(async_payments)]
-	pub fn verify_for_async_payment(
-		&self, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
-	) -> Result<(), ()> {
-		signer::verify_async_payment_id(*self, hmac, nonce, expanded_key)
-	}
-}
-
-impl Verification for PaymentId {
-	/// Constructs an HMAC to include in [`OffersContext::OutboundPayment`] for the payment id
-	/// along with the given [`Nonce`].
-	fn hmac_for_offer_payment(
-		&self, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
-	) -> Hmac<Sha256> {
-		signer::hmac_for_offer_payment_id(*self, nonce, expanded_key)
-	}
-
-	/// Authenticates the payment id using an HMAC and a [`Nonce`] taken from an
-	/// [`OffersContext::OutboundPayment`].
-	fn verify_for_offer_payment(
-		&self, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &inbound_payment::ExpandedKey,
-	) -> Result<(), ()> {
-		signer::verify_offer_payment_id(*self, hmac, nonce, expanded_key)
-	}
 }
 
 impl PaymentId {
@@ -5291,10 +5237,7 @@ where
 				},
 			};
 
-			let entropy = &*self.entropy_source;
-
 			let enqueue_held_htlc_available_res = self.flow.enqueue_held_htlc_available(
-				entropy,
 				invoice,
 				payment_id,
 				self.get_peers_for_blinded_path(),
@@ -11824,7 +11767,7 @@ where
 
 				let invoice = builder.allow_mpp().build_and_sign(secp_ctx)?;
 
-				self.flow.enqueue_invoice(entropy, invoice.clone(), refund, self.get_peers_for_blinded_path())?;
+				self.flow.enqueue_invoice(invoice.clone(), refund, self.get_peers_for_blinded_path())?;
 
 				Ok(invoice)
 			},
@@ -13825,8 +13768,6 @@ where
 	fn handle_message(
 		&self, message: OffersMessage, context: Option<OffersContext>, responder: Option<Responder>,
 	) -> Option<(OffersMessage, ResponseInstruction)> {
-		let expanded_key = &self.inbound_payment_key;
-
 		macro_rules! handle_pay_invoice_res {
 			($res: expr, $invoice: expr, $logger: expr) => {{
 				let error = match $res {
@@ -13942,12 +13883,7 @@ where
 			#[cfg(async_payments)]
 			OffersMessage::StaticInvoice(invoice) => {
 				let payment_id = match context {
-					Some(OffersContext::OutboundPayment { payment_id, nonce, hmac: Some(hmac) }) => {
-						if payment_id.verify_for_offer_payment(hmac, nonce, expanded_key).is_err() {
-							return None
-						}
-						payment_id
-					},
+					Some(OffersContext::OutboundPayment { payment_id, .. }) => payment_id,
 					_ => return None
 				};
 				let res = self.initiate_async_payment(&invoice, payment_id);
@@ -13955,12 +13891,7 @@ where
 			},
 			OffersMessage::InvoiceError(invoice_error) => {
 				let payment_hash = match context {
-					Some(OffersContext::InboundPayment { payment_hash, nonce, hmac }) => {
-						match payment_hash.verify_for_offer_payment(hmac, nonce, expanded_key) {
-							Ok(_) => Some(payment_hash),
-							Err(_) => None,
-						}
-					},
+					Some(OffersContext::InboundPayment { payment_hash }) => Some(payment_hash),
 					_ => None,
 				};
 
@@ -13968,12 +13899,10 @@ where
 				log_trace!(logger, "Received invoice_error: {}", invoice_error);
 
 				match context {
-					Some(OffersContext::OutboundPayment { payment_id, nonce, hmac: Some(hmac) }) => {
-						if let Ok(()) = payment_id.verify_for_offer_payment(hmac, nonce, expanded_key) {
-							self.abandon_payment_with_reason(
-								payment_id, PaymentFailureReason::InvoiceRequestRejected,
-							);
-						}
+					Some(OffersContext::OutboundPayment { payment_id, .. }) => {
+						self.abandon_payment_with_reason(
+							payment_id, PaymentFailureReason::InvoiceRequestRejected,
+						);
 					},
 					_ => {},
 				}
@@ -14122,15 +14051,18 @@ where
 	fn handle_release_held_htlc(&self, _message: ReleaseHeldHtlc, _context: AsyncPaymentsContext) {
 		#[cfg(async_payments)]
 		{
-			if let Ok(payment_id) = self.flow.verify_outbound_async_payment_context(_context) {
-				if let Err(e) = self.send_payment_for_static_invoice(payment_id) {
-					log_trace!(
-						self.logger,
-						"Failed to release held HTLC with payment id {}: {:?}",
-						payment_id,
-						e
-					);
-				}
+			let payment_id = match _context {
+				AsyncPaymentsContext::OutboundPayment { payment_id } => payment_id,
+				_ => return,
+			};
+
+			if let Err(e) = self.send_payment_for_static_invoice(payment_id) {
+				log_trace!(
+					self.logger,
+					"Failed to release held HTLC with payment id {}: {:?}",
+					payment_id,
+					e
+				);
 			}
 		}
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3761,7 +3761,7 @@ where
 		let flow = OffersMessageFlow::new(
 			ChainHash::using_genesis_block(params.network), params.best_block,
 			our_network_pubkey, current_timestamp, expanded_inbound_key,
-			secp_ctx.clone(), message_router
+			node_signer.get_receive_auth_key(), secp_ctx.clone(), message_router
 		);
 
 		ChannelManager {
@@ -16499,7 +16499,7 @@ where
 			our_network_pubkey,
 			highest_seen_timestamp,
 			expanded_inbound_key,
-			secp_ctx.clone(),
+			args.node_signer.get_receive_auth_key(), secp_ctx.clone(),
 			args.message_router,
 		)
 		.with_async_payments_offers_cache(async_receive_offer_cache);

--- a/lightning/src/offers/signer.rs
+++ b/lightning/src/offers/signer.rs
@@ -21,7 +21,6 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::{Hash, HashEngine};
 use bitcoin::secp256k1::{self, Keypair, PublicKey, Secp256k1, SecretKey};
 use core::fmt;
-use types::payment::PaymentHash;
 
 use crate::prelude::*;
 
@@ -38,22 +37,22 @@ const DERIVED_METADATA_AND_KEYS_HMAC_INPUT: &[u8; 16] = &[2; 16];
 const WITHOUT_ENCRYPTED_PAYMENT_ID_HMAC_INPUT: &[u8; 16] = &[3; 16];
 const WITH_ENCRYPTED_PAYMENT_ID_HMAC_INPUT: &[u8; 16] = &[4; 16];
 
-// HMAC input for a `PaymentId`. The HMAC is used in `OffersContext::OutboundPayment`.
-const OFFER_PAYMENT_ID_HMAC_INPUT: &[u8; 16] = &[5; 16];
-// HMAC input for a `PaymentId`. The HMAC is used in `AsyncPaymentsContext::OutboundPayment`.
-#[cfg(async_payments)]
-const ASYNC_PAYMENT_ID_HMAC_INPUT: &[u8; 16] = &[6; 16];
-
-// HMAC input for a `PaymentHash`. The HMAC is used in `OffersContext::InboundPayment`.
-const PAYMENT_HASH_HMAC_INPUT: &[u8; 16] = &[7; 16];
+// NOTE:
+// The following `HMAC_INPUT` constants were previously used for authenticating fields
+// in `OffersContext` and `AsyncPaymentsContext`, but were removed in LDK v0.2 with
+// the introduction of `ReceiveAuthKey`-based authentication.
+// Their corresponding values (`[5; 16]`, `[7; 16]`, and `[9; 16]`) are now
+// reserved and must not be reused to preserve backward compatibility.
+//
+// Reserved HMAC_INPUT values — do not reuse:
+//
+// const OFFER_PAYMENT_ID_HMAC_INPUT: &[u8; 16] = &[5; 16];
+// const PAYMENT_HASH_HMAC_INPUT: &[u8; 16] = &[7; 16];
+// #[cfg(async_payments)]
+// const ASYNC_PAYMENTS_HELD_HTLC_HMAC_INPUT: &[u8; 16] = &[9; 16];
 
 // HMAC input for `ReceiveTlvs`. The HMAC is used in `blinded_path::payment::PaymentContext`.
 const PAYMENT_TLVS_HMAC_INPUT: &[u8; 16] = &[8; 16];
-
-// HMAC input used in `AsyncPaymentsContext::InboundPayment` to authenticate inbound
-// held_htlc_available onion messages.
-#[cfg(async_payments)]
-const ASYNC_PAYMENTS_HELD_HTLC_HMAC_INPUT: &[u8; 16] = &[9; 16];
 
 /// Message metadata which possibly is derived from [`MetadataMaterial`] such that it can be
 /// verified.
@@ -453,76 +452,6 @@ fn hmac_for_message<'a>(
 	Ok(hmac)
 }
 
-pub(crate) fn hmac_for_offer_payment_id(
-	payment_id: PaymentId, nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Hmac<Sha256> {
-	hmac_for_payment_id(payment_id, nonce, OFFER_PAYMENT_ID_HMAC_INPUT, expanded_key)
-}
-
-pub(crate) fn verify_offer_payment_id(
-	payment_id: PaymentId, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Result<(), ()> {
-	if hmac_for_offer_payment_id(payment_id, nonce, expanded_key) == hmac {
-		Ok(())
-	} else {
-		Err(())
-	}
-}
-
-pub(crate) fn hmac_for_payment_hash(
-	payment_hash: PaymentHash, nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Hmac<Sha256> {
-	const IV_BYTES: &[u8; IV_LEN] = b"LDK Payment Hash";
-	let mut hmac = expanded_key.hmac_for_offer();
-	hmac.input(IV_BYTES);
-	hmac.input(&nonce.0);
-	hmac.input(PAYMENT_HASH_HMAC_INPUT);
-	hmac.input(&payment_hash.0);
-
-	Hmac::from_engine(hmac)
-}
-
-pub(crate) fn verify_payment_hash(
-	payment_hash: PaymentHash, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Result<(), ()> {
-	if hmac_for_payment_hash(payment_hash, nonce, expanded_key) == hmac {
-		Ok(())
-	} else {
-		Err(())
-	}
-}
-
-#[cfg(async_payments)]
-pub(crate) fn hmac_for_async_payment_id(
-	payment_id: PaymentId, nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Hmac<Sha256> {
-	hmac_for_payment_id(payment_id, nonce, ASYNC_PAYMENT_ID_HMAC_INPUT, expanded_key)
-}
-
-#[cfg(async_payments)]
-pub(crate) fn verify_async_payment_id(
-	payment_id: PaymentId, hmac: Hmac<Sha256>, nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Result<(), ()> {
-	if hmac_for_async_payment_id(payment_id, nonce, expanded_key) == hmac {
-		Ok(())
-	} else {
-		Err(())
-	}
-}
-
-fn hmac_for_payment_id(
-	payment_id: PaymentId, nonce: Nonce, hmac_input: &[u8; 16], expanded_key: &ExpandedKey,
-) -> Hmac<Sha256> {
-	const IV_BYTES: &[u8; IV_LEN] = b"LDK Payment ID ~";
-	let mut hmac = expanded_key.hmac_for_offer();
-	hmac.input(IV_BYTES);
-	hmac.input(&nonce.0);
-	hmac.input(hmac_input);
-	hmac.input(&payment_id.0);
-
-	Hmac::from_engine(hmac)
-}
-
 pub(crate) fn hmac_for_payment_tlvs(
 	receive_tlvs: &UnauthenticatedReceiveTlvs, nonce: Nonce, expanded_key: &ExpandedKey,
 ) -> Hmac<Sha256> {
@@ -541,30 +470,6 @@ pub(crate) fn verify_payment_tlvs(
 	expanded_key: &ExpandedKey,
 ) -> Result<(), ()> {
 	if hmac_for_payment_tlvs(receive_tlvs, nonce, expanded_key) == hmac {
-		Ok(())
-	} else {
-		Err(())
-	}
-}
-
-#[cfg(async_payments)]
-pub(crate) fn hmac_for_held_htlc_available_context(
-	nonce: Nonce, expanded_key: &ExpandedKey,
-) -> Hmac<Sha256> {
-	const IV_BYTES: &[u8; IV_LEN] = b"LDK Held HTLC OM";
-	let mut hmac = expanded_key.hmac_for_offer();
-	hmac.input(IV_BYTES);
-	hmac.input(&nonce.0);
-	hmac.input(ASYNC_PAYMENTS_HELD_HTLC_HMAC_INPUT);
-
-	Hmac::from_engine(hmac)
-}
-
-#[cfg(async_payments)]
-pub(crate) fn verify_held_htlc_available_context(
-	nonce: Nonce, hmac: Hmac<Sha256>, expanded_key: &ExpandedKey,
-) -> Result<(), ()> {
-	if hmac_for_held_htlc_available_context(nonce, expanded_key) == hmac {
 		Ok(())
 	} else {
 		Err(())

--- a/lightning/src/onion_message/functional_tests.rs
+++ b/lightning/src/onion_message/functional_tests.rs
@@ -432,8 +432,10 @@ fn one_blinded_hop() {
 	let secp_ctx = Secp256k1::new();
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[1].entropy_source;
+	let receive_key = nodes[1].messenger.node_signer.get_receive_auth_key();
 	let blinded_path =
-		BlindedMessagePath::new(&[], nodes[1].node_id, context, entropy, &secp_ctx).unwrap();
+		BlindedMessagePath::new(&[], nodes[1].node_id, receive_key, context, entropy, &secp_ctx)
+			.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 	nodes[0].messenger.send_onion_message(test_msg, instructions).unwrap();
@@ -451,9 +453,16 @@ fn two_unblinded_two_blinded() {
 		[MessageForwardNode { node_id: nodes[3].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[4].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[4].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[4].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[4].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let path = OnionMessagePath {
 		intermediate_nodes: vec![nodes[1].node_id, nodes[2].node_id],
 		destination: Destination::BlindedPath(blinded_path),
@@ -477,9 +486,16 @@ fn three_blinded_hops() {
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[3].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[3].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[3].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[3].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -504,8 +520,10 @@ fn async_response_over_one_blinded_hop() {
 	let secp_ctx = Secp256k1::new();
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[1].entropy_source;
+	let receive_key = nodes[1].messenger.node_signer.get_receive_auth_key();
 	let reply_path =
-		BlindedMessagePath::new(&[], nodes[1].node_id, context, entropy, &secp_ctx).unwrap();
+		BlindedMessagePath::new(&[], nodes[1].node_id, receive_key, context, entropy, &secp_ctx)
+			.unwrap();
 
 	// 4. Create a responder using the reply path for Alice.
 	let responder = Some(Responder::new(reply_path));
@@ -543,8 +561,10 @@ fn async_response_with_reply_path_succeeds() {
 	// Alice receives a message from Bob with an added reply_path for responding back.
 	let message = TestCustomMessage::Ping;
 	let context = MessageContext::Custom(Vec::new());
+	let entropy = &*bob.entropy_source;
+	let receive_key = bob.messenger.node_signer.get_receive_auth_key();
 	let reply_path =
-		BlindedMessagePath::new(&[], bob.node_id, context, &*bob.entropy_source, &secp_ctx)
+		BlindedMessagePath::new(&[], bob.node_id, receive_key, context, entropy, &secp_ctx)
 			.unwrap();
 
 	// Alice asynchronously responds to Bob, expecting a response back from him.
@@ -584,8 +604,10 @@ fn async_response_with_reply_path_fails() {
 	// Alice receives a message from Bob with an added reply_path for responding back.
 	let message = TestCustomMessage::Ping;
 	let context = MessageContext::Custom(Vec::new());
+	let entropy = &*bob.entropy_source;
+	let receive_key = bob.messenger.node_signer.get_receive_auth_key();
 	let reply_path =
-		BlindedMessagePath::new(&[], bob.node_id, context, &*bob.entropy_source, &secp_ctx)
+		BlindedMessagePath::new(&[], bob.node_id, receive_key, context, entropy, &secp_ctx)
 			.unwrap();
 
 	// Alice tries to asynchronously respond to Bob, but fails because the nodes are unannounced and
@@ -634,11 +656,14 @@ fn test_blinded_path_padding_for_full_length_path() {
 	// Update the context to create a larger final receive TLVs, ensuring that
 	// the hop sizes vary before padding.
 	let context = MessageContext::Custom(vec![0u8; 42]);
+	let entropy = &*nodes[3].entropy_source;
+	let receive_key = nodes[3].messenger.node_signer.get_receive_auth_key();
 	let blinded_path = BlindedMessagePath::new(
 		&intermediate_nodes,
 		nodes[3].node_id,
+		receive_key,
 		context,
-		&*nodes[3].entropy_source,
+		entropy,
 		&secp_ctx,
 	)
 	.unwrap();
@@ -667,11 +692,14 @@ fn test_blinded_path_no_padding_for_compact_path() {
 	// Update the context to create a larger final receive TLVs, ensuring that
 	// the hop sizes vary before padding.
 	let context = MessageContext::Custom(vec![0u8; 42]);
+	let entropy = &*nodes[3].entropy_source;
+	let receive_key = nodes[3].messenger.node_signer.get_receive_auth_key();
 	let blinded_path = BlindedMessagePath::new(
 		&intermediate_nodes,
 		nodes[3].node_id,
+		receive_key,
 		context,
-		&*nodes[3].entropy_source,
+		entropy,
 		&secp_ctx,
 	)
 	.unwrap();
@@ -693,9 +721,16 @@ fn we_are_intro_node() {
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[2].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[2].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[2].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -708,9 +743,16 @@ fn we_are_intro_node() {
 		[MessageForwardNode { node_id: nodes[0].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[1].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[1].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[1].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[1].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -731,9 +773,16 @@ fn invalid_blinded_path_error() {
 		[MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[2].entropy_source;
-	let mut blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[2].messenger.node_signer.get_receive_auth_key();
+	let mut blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[2].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	blinded_path.clear_blinded_hops();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
@@ -760,9 +809,16 @@ fn reply_path() {
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[0].entropy_source;
-	let reply_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[0].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[0].messenger.node_signer.get_receive_auth_key();
+	let reply_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[0].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	nodes[0]
 		.messenger
 		.send_onion_message_using_path(path, test_msg.clone(), Some(reply_path))
@@ -781,9 +837,16 @@ fn reply_path() {
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[3].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[3].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[3].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[3].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let intermediate_nodes = [
 		MessageForwardNode { node_id: nodes[2].node_id, short_channel_id: None },
@@ -791,9 +854,16 @@ fn reply_path() {
 	];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[0].entropy_source;
-	let reply_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[0].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[0].messenger.node_signer.get_receive_auth_key();
+	let reply_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[0].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let instructions = MessageSendInstructions::WithSpecifiedReplyPath { destination, reply_path };
 
 	nodes[0].messenger.send_onion_message(test_msg, instructions).unwrap();
@@ -889,9 +959,16 @@ fn requests_peer_connection_for_buffered_messages() {
 		[MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[0].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[0].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[2].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -931,9 +1008,16 @@ fn drops_buffered_messages_waiting_for_peer_connection() {
 		[MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[0].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[0].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[2].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 
@@ -989,9 +1073,16 @@ fn intercept_offline_peer_oms() {
 		[MessageForwardNode { node_id: nodes[1].node_id, short_channel_id: None }];
 	let context = MessageContext::Custom(Vec::new());
 	let entropy = &*nodes[2].entropy_source;
-	let blinded_path =
-		BlindedMessagePath::new(&intermediate_nodes, nodes[2].node_id, context, entropy, &secp_ctx)
-			.unwrap();
+	let receive_key = nodes[2].messenger.node_signer.get_receive_auth_key();
+	let blinded_path = BlindedMessagePath::new(
+		&intermediate_nodes,
+		nodes[2].node_id,
+		receive_key,
+		context,
+		entropy,
+		&secp_ctx,
+	)
+	.unwrap();
 	let destination = Destination::BlindedPath(blinded_path);
 	let instructions = MessageSendInstructions::WithoutReplyPath { destination };
 

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -2283,12 +2283,7 @@ fn packet_payloads_and_keys<
 		unblinded_path.into_iter(),
 		destination,
 		session_priv,
-		|_,
-		 onion_packet_ss,
-		 ephemeral_pubkey,
-		 control_tlvs_ss,
-		 unblinded_pk_opt,
-		 enc_payload_opt| {
+		|onion_packet_ss, ephemeral_pubkey, control_tlvs_ss, unblinded_pk_opt, enc_payload_opt| {
 			if num_unblinded_hops != 0 && unblinded_path_idx < num_unblinded_hops {
 				if let Some(ss) = prev_control_tlvs_ss.take() {
 					payloads.push((

--- a/lightning/src/onion_message/messenger.rs
+++ b/lightning/src/onion_message/messenger.rs
@@ -195,6 +195,7 @@ where
 /// # use lightning::ln::peer_handler::IgnoringMessageHandler;
 /// # use lightning::onion_message::messenger::{Destination, MessageRouter, MessageSendInstructions, OnionMessagePath, OnionMessenger};
 /// # use lightning::onion_message::packet::OnionMessageContents;
+/// # use lightning::sign::{NodeSigner, ReceiveAuthKey};
 /// # use lightning::util::logger::{Logger, Record};
 /// # use lightning::util::ser::{Writeable, Writer};
 /// # use lightning::io;
@@ -217,7 +218,8 @@ where
 /// #         })
 /// #     }
 /// #     fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-/// #         &self, _recipient: PublicKey, _context: MessageContext, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>
+/// #         &self, _recipient: PublicKey, _local_node_receive_key: ReceiveAuthKey,
+/// #         _context: MessageContext, _peers: Vec<PublicKey>, _secp_ctx: &Secp256k1<T>
 /// #     ) -> Result<Vec<BlindedMessagePath>, ()> {
 /// #         unreachable!()
 /// #     }
@@ -273,7 +275,8 @@ where
 /// 	MessageForwardNode { node_id: hop_node_id4, short_channel_id: None },
 /// ];
 /// let context = MessageContext::Custom(Vec::new());
-/// let blinded_path = BlindedMessagePath::new(&hops, your_node_id, context, &keys_manager, &secp_ctx).unwrap();
+/// let receive_key = keys_manager.get_receive_auth_key();
+/// let blinded_path = BlindedMessagePath::new(&hops, your_node_id, receive_key, context, &keys_manager, &secp_ctx).unwrap();
 ///
 /// // Send a custom onion message to a blinded path.
 /// let destination = Destination::BlindedPath(blinded_path);
@@ -306,6 +309,9 @@ pub struct OnionMessenger<
 	CMH::Target: CustomOnionMessageHandler,
 {
 	entropy_source: ES,
+	#[cfg(test)]
+	pub(super) node_signer: NS,
+	#[cfg(not(test))]
 	node_signer: NS,
 	logger: L,
 	message_recipients: Mutex<HashMap<PublicKey, OnionMessageRecipient>>,
@@ -501,8 +507,8 @@ pub trait MessageRouter {
 	/// Creates [`BlindedMessagePath`]s to the `recipient` node. The nodes in `peers` are assumed to
 	/// be direct peers with the `recipient`.
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, recipient: PublicKey, context: MessageContext, peers: Vec<PublicKey>,
-		secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()>;
 
 	/// Creates compact [`BlindedMessagePath`]s to the `recipient` node. The nodes in `peers` are
@@ -519,14 +525,14 @@ pub trait MessageRouter {
 	/// The provided implementation simply delegates to [`MessageRouter::create_blinded_paths`],
 	/// ignoring the short channel ids.
 	fn create_compact_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, recipient: PublicKey, context: MessageContext, peers: Vec<MessageForwardNode>,
-		secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		let peers = peers
 			.into_iter()
 			.map(|MessageForwardNode { node_id, short_channel_id: _ }| node_id)
 			.collect();
-		self.create_blinded_paths(recipient, context, peers, secp_ctx)
+		self.create_blinded_paths(recipient, local_node_receive_key, context, peers, secp_ctx)
 	}
 }
 
@@ -561,8 +567,9 @@ where
 		I: ExactSizeIterator<Item = MessageForwardNode>,
 		T: secp256k1::Signing + secp256k1::Verification,
 	>(
-		network_graph: &G, recipient: PublicKey, context: MessageContext, peers: I,
-		entropy_source: &ES, secp_ctx: &Secp256k1<T>, compact_paths: bool,
+		network_graph: &G, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: I, entropy_source: &ES, secp_ctx: &Secp256k1<T>,
+		compact_paths: bool,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		// Limit the number of blinded paths that are computed.
 		const MAX_PATHS: usize = 3;
@@ -601,7 +608,14 @@ where
 		let paths = peer_info
 			.into_iter()
 			.map(|(peer, _, _)| {
-				BlindedMessagePath::new(&[peer], recipient, context.clone(), entropy, secp_ctx)
+				BlindedMessagePath::new(
+					&[peer],
+					recipient,
+					local_node_receive_key,
+					context.clone(),
+					entropy,
+					secp_ctx,
+				)
 			})
 			.take(MAX_PATHS)
 			.collect::<Result<Vec<_>, _>>();
@@ -610,8 +624,15 @@ where
 			Ok(paths) if !paths.is_empty() => Ok(paths),
 			_ => {
 				if is_recipient_announced {
-					BlindedMessagePath::new(&[], recipient, context, &**entropy_source, secp_ctx)
-						.map(|path| vec![path])
+					BlindedMessagePath::new(
+						&[],
+						recipient,
+						local_node_receive_key,
+						context,
+						&**entropy_source,
+						secp_ctx,
+					)
+					.map(|path| vec![path])
 				} else {
 					Err(())
 				}
@@ -669,14 +690,16 @@ where
 	}
 
 	pub(crate) fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		network_graph: &G, recipient: PublicKey, context: MessageContext, peers: Vec<PublicKey>,
-		entropy_source: &ES, secp_ctx: &Secp256k1<T>,
+		network_graph: &G, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: Vec<PublicKey>, entropy_source: &ES,
+		secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		let peers =
 			peers.into_iter().map(|node_id| MessageForwardNode { node_id, short_channel_id: None });
 		Self::create_blinded_paths_from_iter(
 			network_graph,
 			recipient,
+			local_node_receive_key,
 			context,
 			peers.into_iter(),
 			entropy_source,
@@ -686,12 +709,14 @@ where
 	}
 
 	pub(crate) fn create_compact_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		network_graph: &G, recipient: PublicKey, context: MessageContext,
-		peers: Vec<MessageForwardNode>, entropy_source: &ES, secp_ctx: &Secp256k1<T>,
+		network_graph: &G, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: Vec<MessageForwardNode>, entropy_source: &ES,
+		secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		Self::create_blinded_paths_from_iter(
 			network_graph,
 			recipient,
+			local_node_receive_key,
 			context,
 			peers.into_iter(),
 			entropy_source,
@@ -714,12 +739,13 @@ where
 	}
 
 	fn create_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, recipient: PublicKey, context: MessageContext, peers: Vec<PublicKey>,
-		secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: Vec<PublicKey>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		Self::create_blinded_paths(
 			&self.network_graph,
 			recipient,
+			local_node_receive_key,
 			context,
 			peers,
 			&self.entropy_source,
@@ -728,12 +754,13 @@ where
 	}
 
 	fn create_compact_blinded_paths<T: secp256k1::Signing + secp256k1::Verification>(
-		&self, recipient: PublicKey, context: MessageContext, peers: Vec<MessageForwardNode>,
-		secp_ctx: &Secp256k1<T>,
+		&self, recipient: PublicKey, local_node_receive_key: ReceiveAuthKey,
+		context: MessageContext, peers: Vec<MessageForwardNode>, secp_ctx: &Secp256k1<T>,
 	) -> Result<Vec<BlindedMessagePath>, ()> {
 		Self::create_compact_blinded_paths(
 			&self.network_graph,
 			recipient,
+			local_node_receive_key,
 			context,
 			peers,
 			&self.entropy_source,
@@ -1074,7 +1101,7 @@ where
 			},
 		}
 	};
-	let receiving_context_auth_key = ReceiveAuthKey([41; 32]); // TODO: pass this in
+	let receiving_context_auth_key = node_signer.get_receive_auth_key();
 	let next_hop = onion_utils::decode_next_untagged_hop(
 		onion_decode_ss,
 		&msg.onion_routing_packet.hop_data[..],
@@ -1459,7 +1486,13 @@ where
 		};
 
 		self.message_router
-			.create_blinded_paths(recipient, context, peers, secp_ctx)
+			.create_blinded_paths(
+				recipient,
+				self.node_signer.get_receive_auth_key(),
+				context,
+				peers,
+				secp_ctx,
+			)
 			.and_then(|paths| paths.into_iter().next().ok_or(()))
 			.map_err(|_| SendError::PathNotFound)
 	}

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -804,6 +804,15 @@ pub struct PeerStorageKey {
 	pub inner: [u8; 32],
 }
 
+/// A secret key used to authenticate message contexts in received [`BlindedMessagePath`]s.
+///
+/// This key ensures that a node only accepts incoming messages delivered through
+/// blinded paths that it constructed itself.
+///
+/// [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ReceiveAuthKey(pub [u8; 32]);
+
 /// Specifies the recipient of an invoice.
 ///
 /// This indicates to [`NodeSigner::sign_invoice`] what node secret key should be used to sign

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -860,6 +860,19 @@ pub trait NodeSigner {
 	/// can be re-derived from data which would be available after state loss (eg the wallet seed).
 	fn get_peer_storage_key(&self) -> PeerStorageKey;
 
+	/// Returns the [`ReceiveAuthKey`] used to authenticate incoming [`BlindedMessagePath`] contexts.
+	///
+	/// This key is used as additional associated data (AAD) during MAC verification of the
+	/// [`MessageContext`] at the final hop of a blinded path. It ensures that only paths
+	/// constructed by this node will be accepted, preventing unauthorized parties from forging
+	/// valid-looking messages.
+	///
+	/// Implementers must ensure that this key remains secret and consistent across invocations.
+	///
+	/// [`BlindedMessagePath`]: crate::blinded_path::message::BlindedMessagePath
+	/// [`MessageContext`]: crate::blinded_path::message::MessageContext
+	fn get_receive_auth_key(&self) -> ReceiveAuthKey;
+
 	/// Get node id based on the provided [`Recipient`].
 	///
 	/// This method must return the same value each time it is called with a given [`Recipient`]
@@ -1836,6 +1849,7 @@ pub struct KeysManager {
 	channel_master_key: Xpriv,
 	channel_child_index: AtomicUsize,
 	peer_storage_key: PeerStorageKey,
+	receive_auth_key: ReceiveAuthKey,
 
 	#[cfg(test)]
 	pub(crate) entropy_source: RandomBytes,
@@ -1873,6 +1887,7 @@ impl KeysManager {
 		const CHANNEL_MASTER_KEY_INDEX: ChildNumber = ChildNumber::Hardened { index: 3 };
 		const INBOUND_PAYMENT_KEY_INDEX: ChildNumber = ChildNumber::Hardened { index: 5 };
 		const PEER_STORAGE_KEY_INDEX: ChildNumber = ChildNumber::Hardened { index: 6 };
+		const RECEIVE_AUTH_KEY_INDEX: ChildNumber = ChildNumber::Hardened { index: 7 };
 
 		let secp_ctx = Secp256k1::new();
 		// Note that when we aren't serializing the key, network doesn't matter
@@ -1915,6 +1930,11 @@ impl KeysManager {
 					.expect("Your RNG is busted")
 					.private_key;
 
+				let receive_auth_key = master_key
+					.derive_priv(&secp_ctx, &RECEIVE_AUTH_KEY_INDEX)
+					.expect("Your RNG is busted")
+					.private_key;
+
 				let mut rand_bytes_engine = Sha256::engine();
 				rand_bytes_engine.input(&starting_time_secs.to_be_bytes());
 				rand_bytes_engine.input(&starting_time_nanos.to_be_bytes());
@@ -1930,6 +1950,7 @@ impl KeysManager {
 					inbound_payment_key: ExpandedKey::new(inbound_pmt_key_bytes),
 
 					peer_storage_key: PeerStorageKey { inner: peer_storage_key.secret_bytes() },
+					receive_auth_key: ReceiveAuthKey(receive_auth_key.secret_bytes()),
 
 					destination_script,
 					shutdown_pubkey,
@@ -2160,6 +2181,10 @@ impl NodeSigner for KeysManager {
 		self.peer_storage_key.clone()
 	}
 
+	fn get_receive_auth_key(&self) -> ReceiveAuthKey {
+		self.receive_auth_key.clone()
+	}
+
 	fn sign_invoice(
 		&self, invoice: &RawBolt11Invoice, recipient: Recipient,
 	) -> Result<RecoverableSignature, ()> {
@@ -2323,6 +2348,10 @@ impl NodeSigner for PhantomKeysManager {
 
 	fn get_peer_storage_key(&self) -> PeerStorageKey {
 		self.inner.peer_storage_key.clone()
+	}
+
+	fn get_receive_auth_key(&self) -> ReceiveAuthKey {
+		self.inner.receive_auth_key.clone()
 	}
 
 	fn sign_invoice(

--- a/lightning/src/util/dyn_signer.rs
+++ b/lightning/src/util/dyn_signer.rs
@@ -14,8 +14,8 @@ use crate::ln::script::ShutdownScript;
 use crate::sign::ecdsa::EcdsaChannelSigner;
 #[cfg(taproot)]
 use crate::sign::taproot::TaprootChannelSigner;
-use crate::sign::ChannelSigner;
 use crate::sign::InMemorySigner;
+use crate::sign::{ChannelSigner, ReceiveAuthKey};
 use crate::sign::{EntropySource, HTLCDescriptor, OutputSpender, PhantomKeysManager};
 use crate::sign::{
 	NodeSigner, PeerStorageKey, Recipient, SignerProvider, SpendableOutputDescriptor,
@@ -217,7 +217,8 @@ inner,
 		invoice: &crate::offers::invoice::UnsignedBolt12Invoice
 	) -> Result<secp256k1::schnorr::Signature, ()>,
 	fn get_inbound_payment_key(,) -> ExpandedKey,
-	fn get_peer_storage_key(,) -> PeerStorageKey
+	fn get_peer_storage_key(,) -> PeerStorageKey,
+	fn get_receive_auth_key(,) -> ReceiveAuthKey
 );
 
 delegate!(DynKeysInterface, SignerProvider,
@@ -282,7 +283,8 @@ delegate!(DynPhantomKeysInterface, NodeSigner,
 	fn sign_bolt12_invoice(, invoice: &crate::offers::invoice::UnsignedBolt12Invoice
 	) -> Result<secp256k1::schnorr::Signature, ()>,
 	fn get_inbound_payment_key(,) -> ExpandedKey,
-	fn get_peer_storage_key(,) -> PeerStorageKey
+	fn get_peer_storage_key(,) -> PeerStorageKey,
+	fn get_receive_auth_key(,) -> ReceiveAuthKey
 );
 
 impl SignerProvider for DynPhantomKeysInterface {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a receive authentication key to enhance security for blinded message paths and onion message processing.
  * Blinded path creation and message routing now require explicit use of the receive authentication key.

* **Refactor**
  * Simplified message context structures by removing nonce and HMAC fields from offer and async payment contexts.
  * Updated trait and function signatures across the codebase to accommodate the new receive authentication key.
  * Removed HMAC verification for offer payment IDs, payment hashes, and async payment held HTLC contexts.

* **Bug Fixes**
  * Improved validation and authentication of control TLVs in onion message payloads.

* **Tests**
  * Updated test utilities and test cases to use the new receive authentication key in blinded path operations.

* **Chores**
  * Unified cryptographic implementations and improved test coverage for Poly1305 and ChaCha20Poly1305RFC.
  * Added support for a ChaCha20Poly1305 variant with swapped AAD placement and dual MAC verification during decryption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->