### PR TITLE
Review Branch: Dummy Hop support for Blinded Payment Path

### DIFF
--- a/lightning-dns-resolver/src/lib.rs
+++ b/lightning-dns-resolver/src/lib.rs
@@ -175,6 +175,7 @@ mod test {
 	use lightning::onion_message::messenger::{
 		AOnionMessenger, Destination, MessageRouter, OnionMessagePath, OnionMessenger,
 	};
+	use lightning::routing::router::DEFAULT_PAYMENT_DUMMY_HOPS;
 	use lightning::sign::{KeysManager, NodeSigner, ReceiveAuthKey, Recipient};
 	use lightning::types::features::InitFeatures;
 	use lightning::types::payment::PaymentHash;
@@ -419,6 +420,11 @@ mod test {
 		let updates = get_htlc_update_msgs(&nodes[0], &payee_id);
 		nodes[1].node.handle_update_add_htlc(payer_id, &updates.update_add_htlcs[0]);
 		do_commitment_signed_dance(&nodes[1], &nodes[0], &updates.commitment_signed, false, false);
+
+		for _ in 0..DEFAULT_PAYMENT_DUMMY_HOPS {
+			nodes[1].node.process_pending_htlc_forwards();
+		}
+
 		expect_and_process_pending_htlcs(&nodes[1], false);
 
 		let claimable_events = nodes[1].node.get_and_clear_pending_events();

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -34,7 +34,6 @@ use crate::util::ser::{
 	Writeable, Writer,
 };
 
-use core::mem;
 use core::ops::Deref;
 
 #[allow(unused_imports)]
@@ -219,28 +218,31 @@ impl BlindedPaymentPath {
 		NL::Target: NodeIdLookUp,
 		T: secp256k1::Signing + secp256k1::Verification,
 	{
-		match self.decrypt_intro_payload::<NS>(node_signer) {
-			Ok((
-				BlindedPaymentTlvs::Forward(ForwardTlvs { short_channel_id, .. }),
-				control_tlvs_ss,
-			)) => {
-				let next_node_id = match node_id_lookup.next_node_id(short_channel_id) {
-					Some(node_id) => node_id,
-					None => return Err(()),
-				};
-				let mut new_blinding_point = onion_utils::next_hop_pubkey(
-					secp_ctx,
-					self.inner_path.blinding_point,
-					control_tlvs_ss.as_ref(),
-				)
-				.map_err(|_| ())?;
-				mem::swap(&mut self.inner_path.blinding_point, &mut new_blinding_point);
-				self.inner_path.introduction_node = IntroductionNode::NodeId(next_node_id);
-				self.inner_path.blinded_hops.remove(0);
-				Ok(())
-			},
-			_ => Err(()),
-		}
+		let (next_node_id, control_tlvs_ss) =
+			match self.decrypt_intro_payload::<NS>(node_signer).map_err(|_| ())? {
+				(BlindedPaymentTlvs::Forward(ForwardTlvs { short_channel_id, .. }), ss) => {
+					let node_id = node_id_lookup.next_node_id(short_channel_id).ok_or(())?;
+					(node_id, ss)
+				},
+				(BlindedPaymentTlvs::Dummy, ss) => {
+					let node_id = node_signer.get_node_id(Recipient::Node)?;
+					(node_id, ss)
+				},
+				_ => return Err(()),
+			};
+
+		let new_blinding_point = onion_utils::next_hop_pubkey(
+			secp_ctx,
+			self.inner_path.blinding_point,
+			control_tlvs_ss.as_ref(),
+		)
+		.map_err(|_| ())?;
+
+		self.inner_path.blinding_point = new_blinding_point;
+		self.inner_path.introduction_node = IntroductionNode::NodeId(next_node_id);
+		self.inner_path.blinded_hops.remove(0);
+
+		Ok(())
 	}
 
 	pub(crate) fn decrypt_intro_payload<NS: Deref>(
@@ -262,9 +264,9 @@ impl BlindedPaymentPath {
 				.map_err(|_| ())?;
 
 		match (&readable, used_aad) {
-			(BlindedPaymentTlvs::Forward(_), false) | (BlindedPaymentTlvs::Receive(_), true) => {
-				Ok((readable, control_tlvs_ss))
-			},
+			(BlindedPaymentTlvs::Forward(_), false)
+			| (BlindedPaymentTlvs::Dummy, true)
+			| (BlindedPaymentTlvs::Receive(_), true) => Ok((readable, control_tlvs_ss)),
 			_ => Err(()),
 		}
 	}

--- a/lightning/src/blinded_path/payment.rs
+++ b/lightning/src/blinded_path/payment.rs
@@ -12,6 +12,7 @@
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1::{self, PublicKey, Secp256k1, SecretKey};
 
+use crate::blinded_path::message::MAX_DUMMY_HOPS_COUNT;
 use crate::blinded_path::utils::{self, BlindedPathWithPadding};
 use crate::blinded_path::{BlindedHop, BlindedPath, IntroductionNode, NodeIdLookUp};
 use crate::crypto::streams::ChaChaDualPolyReadAdapter;
@@ -124,6 +125,32 @@ impl BlindedPaymentPath {
 	where
 		ES::Target: EntropySource,
 	{
+		BlindedPaymentPath::new_with_dummy_hops(
+			intermediate_nodes,
+			payee_node_id,
+			0,
+			local_node_receive_key,
+			payee_tlvs,
+			htlc_maximum_msat,
+			min_final_cltv_expiry_delta,
+			entropy_source,
+			secp_ctx,
+		)
+	}
+
+	/// Same as [`BlindedPaymentPath::new`], but allows specifying a number of dummy hops.
+	///
+	/// Note:
+	/// At most [`MAX_DUMMY_HOPS_COUNT`] dummy hops can be added to the blinded path.
+	pub fn new_with_dummy_hops<ES: Deref, T: secp256k1::Signing + secp256k1::Verification>(
+		intermediate_nodes: &[PaymentForwardNode], payee_node_id: PublicKey,
+		dummy_hop_count: usize, local_node_receive_key: ReceiveAuthKey, payee_tlvs: ReceiveTlvs,
+		htlc_maximum_msat: u64, min_final_cltv_expiry_delta: u16, entropy_source: ES,
+		secp_ctx: &Secp256k1<T>,
+	) -> Result<Self, ()>
+	where
+		ES::Target: EntropySource,
+	{
 		let introduction_node = IntroductionNode::NodeId(
 			intermediate_nodes.first().map_or(payee_node_id, |n| n.node_id),
 		);
@@ -145,6 +172,7 @@ impl BlindedPaymentPath {
 					secp_ctx,
 					intermediate_nodes,
 					payee_node_id,
+					dummy_hop_count,
 					payee_tlvs,
 					&blinding_secret,
 					local_node_receive_key,
@@ -644,22 +672,46 @@ pub(crate) const PAYMENT_PADDING_ROUND_OFF: usize = 30;
 /// Construct blinded payment hops for the given `intermediate_nodes` and payee info.
 pub(super) fn blinded_hops<T: secp256k1::Signing + secp256k1::Verification>(
 	secp_ctx: &Secp256k1<T>, intermediate_nodes: &[PaymentForwardNode], payee_node_id: PublicKey,
-	payee_tlvs: ReceiveTlvs, session_priv: &SecretKey, local_node_receive_key: ReceiveAuthKey,
+	dummy_hop_count: usize, payee_tlvs: ReceiveTlvs, session_priv: &SecretKey,
+	local_node_receive_key: ReceiveAuthKey,
 ) -> Vec<BlindedHop> {
+	let dummy_count = core::cmp::min(dummy_hop_count, MAX_DUMMY_HOPS_COUNT);
 	let pks = intermediate_nodes
 		.iter()
 		.map(|node| (node.node_id, None))
+		.chain(core::iter::repeat((payee_node_id, Some(local_node_receive_key))).take(dummy_count))
 		.chain(core::iter::once((payee_node_id, Some(local_node_receive_key))));
 	let tlvs = intermediate_nodes
 		.iter()
 		.map(|node| BlindedPaymentTlvsRef::Forward(&node.tlvs))
+		.chain((0..dummy_count).map(|_| BlindedPaymentTlvsRef::Dummy))
 		.chain(core::iter::once(BlindedPaymentTlvsRef::Receive(&payee_tlvs)));
 
-	let path = pks.zip(
-		tlvs.map(|tlv| BlindedPathWithPadding { tlvs: tlv, round_off: PAYMENT_PADDING_ROUND_OFF }),
-	);
+	let path: Vec<_> = pks
+		.zip(
+			tlvs.map(|tlv| BlindedPathWithPadding {
+				tlvs: tlv,
+				round_off: PAYMENT_PADDING_ROUND_OFF,
+			}),
+		)
+		.collect();
 
-	utils::construct_blinded_hops(secp_ctx, path, session_priv)
+	// Debug invariant: all non-final hops must have identical serialized size.
+	#[cfg(debug_assertions)]
+	if let Some((_, first)) = path.first() {
+		if path.len() > 2 {
+			let expected = first.serialized_length();
+
+			for (_, hop) in path.iter().skip(1).take(path.len() - 2) {
+				debug_assert!(
+					hop.serialized_length() == expected,
+					"All intermediate blinded hops must have identical serialized size"
+				);
+			}
+		}
+	}
+
+	utils::construct_blinded_hops(secp_ctx, path.into_iter(), session_priv)
 }
 
 /// `None` if underflow occurs.

--- a/lightning/src/ln/async_payments_tests.rs
+++ b/lightning/src/ln/async_payments_tests.rs
@@ -55,7 +55,7 @@ use crate::onion_message::messenger::{
 use crate::onion_message::offers::OffersMessage;
 use crate::onion_message::packet::ParsedOnionMessageContents;
 use crate::prelude::*;
-use crate::routing::router::{Payee, PaymentParameters};
+use crate::routing::router::{Payee, PaymentParameters, DEFAULT_PAYMENT_DUMMY_HOPS};
 use crate::sign::NodeSigner;
 use crate::sync::Mutex;
 use crate::types::features::Bolt12InvoiceFeatures;
@@ -1858,6 +1858,13 @@ fn expired_static_invoice_payment_path() {
 		blinded_path
 			.advance_path_by_one(&nodes[1].keys_manager, &nodes[1].node, &secp_ctx)
 			.unwrap();
+
+		for _ in 0..DEFAULT_PAYMENT_DUMMY_HOPS {
+			blinded_path
+				.advance_path_by_one(&nodes[2].keys_manager, &nodes[2].node, &secp_ctx)
+				.unwrap();
+		}
+
 		match blinded_path.decrypt_intro_payload(&nodes[2].keys_manager).unwrap().0 {
 			BlindedPaymentTlvs::Receive(tlvs) => tlvs.payment_constraints.max_cltv_expiry,
 			_ => panic!(),

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -1663,8 +1663,9 @@ fn route_blinding_spec_test_vector() {
 		hop_data: carol_packet_bytes,
 		hmac: carol_hmac,
 	};
+	let carol_forward_info = carol_packet_details.next_hop_forward_info.unwrap();
 	let carol_update_add = update_add_msg(
-		carol_packet_details.outgoing_amt_msat, carol_packet_details.outgoing_cltv_value,
+		carol_forward_info.outgoing_amt_msat, carol_forward_info.outgoing_cltv_value,
 		Some(pubkey_from_hex("034e09f450a80c3d252b258aba0a61215bf60dda3b0dc78ffb0736ea1259dfd8a0")),
 		carol_onion
 	);
@@ -1697,8 +1698,9 @@ fn route_blinding_spec_test_vector() {
 		hop_data: dave_packet_bytes,
 		hmac: dave_hmac,
 	};
+	let dave_forward_info = dave_packet_details.next_hop_forward_info.unwrap();
 	let dave_update_add = update_add_msg(
-		dave_packet_details.outgoing_amt_msat, dave_packet_details.outgoing_cltv_value,
+		dave_forward_info.outgoing_amt_msat, dave_forward_info.outgoing_cltv_value,
 		Some(pubkey_from_hex("031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f")),
 		dave_onion
 	);
@@ -1731,8 +1733,9 @@ fn route_blinding_spec_test_vector() {
 		hop_data: eve_packet_bytes,
 		hmac: eve_hmac,
 	};
+	let eve_forward_info = eve_packet_details.next_hop_forward_info.unwrap();
 	let eve_update_add = update_add_msg(
-		eve_packet_details.outgoing_amt_msat, eve_packet_details.outgoing_cltv_value,
+		eve_forward_info.outgoing_amt_msat, eve_forward_info.outgoing_cltv_value,
 		Some(pubkey_from_hex("03e09038ee76e50f444b19abf0a555e8697e035f62937168b80adf0931b31ce52a")),
 		eve_onion
 	);
@@ -1963,7 +1966,8 @@ fn test_trampoline_inbound_payment_decoding() {
 		hop_data: carol_packet_bytes,
 		hmac: carol_hmac,
 	};
-	let carol_update_add = update_add_msg(carol_packet_details.outgoing_amt_msat, carol_packet_details.outgoing_cltv_value, None, carol_onion);
+	let carol_forward_info = carol_packet_details.next_hop_forward_info.unwrap();
+	let carol_update_add = update_add_msg(carol_forward_info.outgoing_amt_msat, carol_forward_info.outgoing_cltv_value, None, carol_onion);
 
 	let carol_node_signer = TestEcdhSigner { node_secret: carol_secret };
 	let (carol_peeled_onion, _) = onion_payment::decode_incoming_update_add_htlc_onion(

--- a/lightning/src/ln/blinded_payment_tests.rs
+++ b/lightning/src/ln/blinded_payment_tests.rs
@@ -191,6 +191,56 @@ fn do_one_hop_blinded_path(success: bool) {
 }
 
 #[test]
+fn one_hop_blinded_path_with_dummy_hops() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let chan_upd = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1_000_000, 0).0.contents;
+
+	let amt_msat = 5000;
+	let (payment_preimage, payment_hash, payment_secret) = get_payment_preimage_hash(&nodes[1], Some(amt_msat), None);
+	let payee_tlvs = ReceiveTlvs {
+		payment_secret,
+		payment_constraints: PaymentConstraints {
+			max_cltv_expiry: u32::max_value(),
+			htlc_minimum_msat: chan_upd.htlc_minimum_msat,
+		},
+		payment_context: PaymentContext::Bolt12Refund(Bolt12RefundContext {}),
+	};
+	let receive_auth_key = chanmon_cfgs[1].keys_manager.get_receive_auth_key();
+	let dummy_hops = 2;
+
+	let mut secp_ctx = Secp256k1::new();
+	let blinded_path = BlindedPaymentPath::new_with_dummy_hops(
+		&[], nodes[1].node.get_our_node_id(), dummy_hops, receive_auth_key,
+		payee_tlvs, u64::MAX, TEST_FINAL_CLTV as u16,
+		&chanmon_cfgs[1].keys_manager, &secp_ctx
+	).unwrap();
+
+	let route_params = RouteParameters::from_payment_params_and_value(
+		PaymentParameters::blinded(vec![blinded_path]),
+		amt_msat,
+	);
+	nodes[0].node.send_payment(payment_hash, RecipientOnionFields::spontaneous_empty(),
+	PaymentId(payment_hash.0), route_params, Retry::Attempts(0)).unwrap();
+	check_added_monitors(&nodes[0], 1);
+
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	let ev = remove_first_msg_event_to_node(&nodes[1].node.get_our_node_id(), &mut events);
+
+	let path = &[&nodes[1]];
+	let args =
+		PassAlongPathArgs::new(&nodes[0], path, amt_msat, payment_hash, ev)
+		.with_dummy_override(dummy_hops)
+		.with_payment_secret(payment_secret);
+
+	do_pass_along_path(args);
+	claim_payment(&nodes[0], &[&nodes[1]], payment_preimage);
+}
+
+#[test]
 fn mpp_to_one_hop_blinded_path() {
 	let chanmon_cfgs = create_chanmon_cfgs(4);
 	let node_cfgs = create_node_cfgs(4, &chanmon_cfgs);

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -66,7 +66,7 @@ use crate::ln::channel_state::ChannelDetails;
 use crate::ln::funding::SpliceContribution;
 use crate::ln::inbound_payment;
 use crate::ln::interactivetxs::InteractiveTxMessageSend;
-use crate::ln::msgs;
+use crate::ln::msgs::{self, OnionPacket, UpdateAddHTLC};
 use crate::ln::msgs::{
 	BaseMessageHandler, ChannelMessageHandler, CommitmentUpdate, DecodeError, LightningError,
 	MessageSendEvent,
@@ -6857,6 +6857,7 @@ where
 	pub(crate) fn process_pending_update_add_htlcs(&self) -> bool {
 		let mut should_persist = false;
 		let mut decode_update_add_htlcs = new_hash_map();
+		let mut dummy_update_add_htlcs = new_hash_map();
 		mem::swap(&mut decode_update_add_htlcs, &mut self.decode_update_add_htlcs.lock().unwrap());
 
 		let get_htlc_failure_type = |outgoing_scid_opt: Option<u64>, payment_hash: PaymentHash| {
@@ -6920,7 +6921,67 @@ where
 						&*self.logger,
 						&self.secp_ctx,
 					) {
-						Ok(decoded_onion) => decoded_onion,
+						Ok(decoded_onion) => match decoded_onion {
+							(
+								onion_utils::Hop::Dummy {
+									intro_node_blinding_point,
+									next_hop_hmac,
+									new_packet_bytes,
+									..
+								},
+								Some(NextPacketDetails {
+									next_packet_pubkey,
+									next_hop_forward_info,
+								}),
+							) => {
+								debug_assert!(
+										next_hop_forward_info.is_none(),
+										"Dummy hops must not contain any forward info, since they are not actually forwarded."
+									);
+
+								// Dummy hops are not forwarded. Instead, we reconstruct a new UpdateAddHTLC
+								// with the next onion packet (ephemeral pubkey, hop data, and HMAC) and push
+								// it back into our own processing queue. This lets us step through the dummy
+								// layers locally until we reach the next real hop.
+								let next_blinding_point = intro_node_blinding_point
+									.or(update_add_htlc.blinding_point)
+									.and_then(|blinding_point| {
+										let ss = self
+											.node_signer
+											.ecdh(Recipient::Node, &blinding_point, None)
+											.ok()?
+											.secret_bytes();
+
+										onion_utils::next_hop_pubkey(
+											&self.secp_ctx,
+											blinding_point,
+											&ss,
+										)
+										.ok()
+									});
+
+								let new_onion_packet = OnionPacket {
+									version: 0,
+									public_key: next_packet_pubkey,
+									hop_data: new_packet_bytes,
+									hmac: next_hop_hmac,
+								};
+
+								let new_update_add_htlc = UpdateAddHTLC {
+									onion_routing_packet: new_onion_packet,
+									blinding_point: next_blinding_point,
+									..update_add_htlc.clone()
+								};
+
+								dummy_update_add_htlcs
+									.entry(incoming_scid_alias)
+									.or_insert_with(Vec::new)
+									.push(new_update_add_htlc);
+
+								continue;
+							},
+							_ => decoded_onion,
+						},
 
 						Err((htlc_fail, reason)) => {
 							let failure_type = HTLCHandlingFailureType::InvalidOnion;
@@ -7077,6 +7138,23 @@ where
 				));
 			}
 		}
+
+		// Merge peeled dummy HTLCs into the existing decode queue so they can be
+		// processed in the next iteration. We avoid replacing the whole queue
+		// (e.g. via mem::swap) because other threads may have enqueued new HTLCs
+		// meanwhile; merging preserves everything safely.
+		if !dummy_update_add_htlcs.is_empty() {
+			let mut decode_update_add_htlc_source =
+				self.decode_update_add_htlcs.lock().unwrap();
+
+			for (incoming_scid_alias, htlcs) in dummy_update_add_htlcs.into_iter() {
+				decode_update_add_htlc_source
+					.entry(incoming_scid_alias)
+					.or_default()
+					.extend(htlcs);
+			}
+		}
+
 		should_persist
 	}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -7144,14 +7144,10 @@ where
 		// (e.g. via mem::swap) because other threads may have enqueued new HTLCs
 		// meanwhile; merging preserves everything safely.
 		if !dummy_update_add_htlcs.is_empty() {
-			let mut decode_update_add_htlc_source =
-				self.decode_update_add_htlcs.lock().unwrap();
+			let mut decode_update_add_htlc_source = self.decode_update_add_htlcs.lock().unwrap();
 
 			for (incoming_scid_alias, htlcs) in dummy_update_add_htlcs.into_iter() {
-				decode_update_add_htlc_source
-					.entry(incoming_scid_alias)
-					.or_default()
-					.extend(htlcs);
+				decode_update_add_htlc_source.entry(incoming_scid_alias).or_default().extend(htlcs);
 			}
 		}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5089,6 +5089,20 @@ where
 			onion_utils::Hop::Forward { .. } | onion_utils::Hop::BlindedForward { .. } => {
 				create_fwd_pending_htlc_info(msg, decoded_hop, shared_secret, next_packet_pubkey_opt)
 			},
+			onion_utils::Hop::Dummy { .. } => {
+				debug_assert!(
+					false,
+					"Reached unreachable dummy-hop HTLC. Dummy hops are peeled in \
+					`process_pending_update_add_htlcs`, and the resulting HTLC is \
+					re-enqueued for processing. Hitting this means the peel-and-requeue \
+					step was missed."
+				);
+				return Err(InboundHTLCErr {
+					msg: "Failed to decode update add htlc onion",
+					reason: LocalHTLCFailureReason::InvalidOnionPayload,
+					err_data: Vec::new(),
+				})
+			},
 			onion_utils::Hop::TrampolineForward { .. } | onion_utils::Hop::TrampolineBlindedForward { .. } => {
 				create_fwd_pending_htlc_info(msg, decoded_hop, shared_secret, next_packet_pubkey_opt)
 			},

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -74,7 +74,7 @@ use crate::ln::msgs::{
 use crate::ln::onion_payment::{
 	check_incoming_htlc_cltv, create_fwd_pending_htlc_info, create_recv_pending_htlc_info,
 	decode_incoming_update_add_htlc_onion, invalid_payment_err_data, HopConnector, InboundHTLCErr,
-	NextPacketDetails,
+	NextHopForwardInfo, NextPacketDetails,
 };
 use crate::ln::onion_utils::{self};
 use crate::ln::onion_utils::{
@@ -4888,7 +4888,7 @@ where
 
 	#[rustfmt::skip]
 	fn can_forward_htlc_to_outgoing_channel(
-		&self, chan: &mut FundedChannel<SP>, msg: &msgs::UpdateAddHTLC, next_packet: &NextPacketDetails
+		&self, chan: &mut FundedChannel<SP>, msg: &msgs::UpdateAddHTLC, forward_info: &NextHopForwardInfo
 	) -> Result<(), LocalHTLCFailureReason> {
 		if !chan.context.should_announce()
 			&& !self.config.read().unwrap().accept_forwards_to_priv_channels
@@ -4898,7 +4898,7 @@ where
 			// we don't allow forwards outbound over them.
 			return Err(LocalHTLCFailureReason::PrivateChannelForward);
 		}
-		if let HopConnector::ShortChannelId(outgoing_scid) = next_packet.outgoing_connector {
+		if let HopConnector::ShortChannelId(outgoing_scid) = forward_info.outgoing_connector {
 			if chan.funding.get_channel_type().supports_scid_privacy() && outgoing_scid != chan.context.outbound_scid_alias() {
 				// `option_scid_alias` (referred to in LDK as `scid_privacy`) means
 				// "refuse to forward unless the SCID alias was used", so we pretend
@@ -4921,10 +4921,10 @@ where
 				return Err(LocalHTLCFailureReason::ChannelNotReady);
 			}
 		}
-		if next_packet.outgoing_amt_msat < chan.context.get_counterparty_htlc_minimum_msat() {
+		if forward_info.outgoing_amt_msat < chan.context.get_counterparty_htlc_minimum_msat() {
 			return Err(LocalHTLCFailureReason::AmountBelowMinimum);
 		}
-		chan.htlc_satisfies_config(msg, next_packet.outgoing_amt_msat, next_packet.outgoing_cltv_value)?;
+		chan.htlc_satisfies_config(msg, forward_info.outgoing_amt_msat, forward_info.outgoing_cltv_value)?;
 
 		Ok(())
 	}
@@ -4956,14 +4956,20 @@ where
 	fn can_forward_htlc(
 		&self, msg: &msgs::UpdateAddHTLC, next_packet_details: &NextPacketDetails
 	) -> Result<(), LocalHTLCFailureReason> {
-		let outgoing_scid = match next_packet_details.outgoing_connector {
+		let next_hop_forward_info = next_packet_details
+			.next_hop_forward_info
+			.as_ref()
+			.ok_or(LocalHTLCFailureReason::InvalidOnionPayload)?;
+
+		let outgoing_scid = match next_hop_forward_info.outgoing_connector {
 			HopConnector::ShortChannelId(scid) => scid,
 			HopConnector::Trampoline(_) => {
 				return Err(LocalHTLCFailureReason::InvalidTrampolineForward);
 			}
 		};
+
 		match self.do_funded_channel_callback(outgoing_scid, |chan: &mut FundedChannel<SP>| {
-			self.can_forward_htlc_to_outgoing_channel(chan, msg, next_packet_details)
+			self.can_forward_htlc_to_outgoing_channel(chan, msg, next_hop_forward_info)
 		}) {
 			Some(Ok(())) => {},
 			Some(Err(e)) => return Err(e),
@@ -4980,7 +4986,7 @@ where
 		}
 
 		let cur_height = self.best_block.read().unwrap().height + 1;
-		check_incoming_htlc_cltv(cur_height, next_packet_details.outgoing_cltv_value, msg.cltv_expiry)?;
+		check_incoming_htlc_cltv(cur_height, next_hop_forward_info.outgoing_cltv_value, msg.cltv_expiry)?;
 
 		Ok(())
 	}
@@ -6924,11 +6930,12 @@ where
 					};
 
 				let is_intro_node_blinded_forward = next_hop.is_intro_node_blinded_forward();
-				let outgoing_scid_opt =
-					next_packet_details_opt.as_ref().and_then(|d| match d.outgoing_connector {
+				let outgoing_scid_opt = next_packet_details_opt.as_ref().and_then(|d| {
+					d.next_hop_forward_info.as_ref().and_then(|f| match f.outgoing_connector {
 						HopConnector::ShortChannelId(scid) => Some(scid),
 						HopConnector::Trampoline(_) => None,
-					});
+					})
+				});
 				let shared_secret = next_hop.shared_secret().secret_bytes();
 
 				// Nodes shouldn't expect us to hold HTLCs for them if we don't advertise htlc_hold feature

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -2355,6 +2355,7 @@ mod fuzzy_internal_msgs {
 		Receive(InboundOnionReceivePayload),
 		BlindedForward(InboundOnionBlindedForwardPayload),
 		BlindedReceive(InboundOnionBlindedReceivePayload),
+		Dummy { intro_node_blinding_point: Option<PublicKey> },
 	}
 
 	pub struct InboundTrampolineForwardPayload {
@@ -3693,6 +3694,17 @@ where
 						intro_node_blinding_point,
 						next_blinding_override,
 					}))
+				},
+				ChaChaDualPolyReadAdapter { readable: BlindedPaymentTlvs::Dummy, used_aad } => {
+					if amt.is_some()
+						|| cltv_value.is_some() || total_msat.is_some()
+						|| keysend_preimage.is_some()
+						|| invoice_request.is_some()
+						|| !used_aad
+					{
+						return Err(DecodeError::InvalidValue);
+					}
+					Ok(Self::Dummy { intro_node_blinding_point })
 				},
 				ChaChaDualPolyReadAdapter {
 					readable: BlindedPaymentTlvs::Receive(receive_tlvs),

--- a/lightning/src/ln/offers_tests.rs
+++ b/lightning/src/ln/offers_tests.rs
@@ -185,7 +185,20 @@ fn route_bolt12_payment<'a, 'b, 'c>(
 fn claim_bolt12_payment<'a, 'b, 'c>(
 	node: &Node<'a, 'b, 'c>, path: &[&Node<'a, 'b, 'c>], expected_payment_context: PaymentContext, invoice: &Bolt12Invoice
 ) {
-	let recipient = &path[path.len() - 1];
+	claim_bolt12_payment_with_extra_fees(
+		node,
+		path,
+		expected_payment_context,
+		invoice,
+		None,
+	)
+}
+
+fn claim_bolt12_payment_with_extra_fees<'a, 'b, 'c>(
+	node: &Node<'a, 'b, 'c>, path: &[&Node<'a, 'b, 'c>], expected_payment_context: PaymentContext, invoice: &Bolt12Invoice,
+	expected_extra_fees_msat: Option<u64>,
+) {
+	let recipient = path.last().expect("Empty path?");
 	let payment_purpose = match get_event!(recipient, Event::PaymentClaimable) {
 		Event::PaymentClaimable { purpose, .. } => purpose,
 		_ => panic!("No Event::PaymentClaimable"),
@@ -194,20 +207,29 @@ fn claim_bolt12_payment<'a, 'b, 'c>(
 		Some(preimage) => preimage,
 		None => panic!("No preimage in Event::PaymentClaimable"),
 	};
-	match payment_purpose {
-		PaymentPurpose::Bolt12OfferPayment { payment_context, .. } => {
-			assert_eq!(PaymentContext::Bolt12Offer(payment_context), expected_payment_context);
-		},
-		PaymentPurpose::Bolt12RefundPayment { payment_context, .. } => {
-			assert_eq!(PaymentContext::Bolt12Refund(payment_context), expected_payment_context);
-		},
+	let context = match payment_purpose {
+		PaymentPurpose::Bolt12OfferPayment { payment_context, .. } =>
+			PaymentContext::Bolt12Offer(payment_context),
+		PaymentPurpose::Bolt12RefundPayment { payment_context, .. } =>
+			PaymentContext::Bolt12Refund(payment_context),
 		_ => panic!("Unexpected payment purpose: {:?}", payment_purpose),
-	}
-	if let Some(inv) = claim_payment(node, path, payment_preimage) {
-		assert_eq!(inv, PaidBolt12Invoice::Bolt12Invoice(invoice.to_owned()));
-	} else {
-		panic!("Expected PaidInvoice::Bolt12Invoice");
 	};
+
+	assert_eq!(context, expected_payment_context);
+
+	let expected_paths = [path];
+	let mut args = ClaimAlongRouteArgs::new(
+		node,
+		&expected_paths,
+		payment_preimage,
+	);
+
+	if let Some(extra) = expected_extra_fees_msat {
+		args = args.with_expected_extra_total_fees_msat(extra);
+	}
+
+	let (inv, _) = claim_payment_along_route(args);
+	assert_eq!(inv, Some(PaidBolt12Invoice::Bolt12Invoice(invoice.clone())));
 }
 
 fn extract_offer_nonce<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>, message: &OnionMessage) -> Nonce {

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -469,16 +469,19 @@ where
 	Ok(match hop {
 		onion_utils::Hop::Forward { shared_secret, .. } |
 		onion_utils::Hop::BlindedForward { shared_secret, .. } => {
-			let NextPacketDetails {
-				next_packet_pubkey, outgoing_amt_msat: _, outgoing_connector: _, outgoing_cltv_value
-			} = match next_packet_details_opt {
-				Some(next_packet_details) => next_packet_details,
+			let (next_packet_pubkey, outgoing_cltv_value) = match next_packet_details_opt {
+				Some(NextPacketDetails {
+					next_packet_pubkey,
+					next_hop_forward_info: Some(NextHopForwardInfo { outgoing_cltv_value, .. }),
+				}) => (next_packet_pubkey, outgoing_cltv_value),
 				// Forward should always include the next hop details
-				None => return Err(InboundHTLCErr {
-					msg: "Failed to decode update add htlc onion",
-					reason: LocalHTLCFailureReason::InvalidOnionPayload,
-					err_data: Vec::new(),
-				}),
+				_ => {
+					return Err(InboundHTLCErr {
+						msg: "Failed to decode update add htlc onion",
+						reason: LocalHTLCFailureReason::InvalidOnionPayload,
+						err_data: Vec::new(),
+					});
+				}
 			};
 
 			if let Err(reason) = check_incoming_htlc_cltv(
@@ -515,6 +518,10 @@ pub(super) enum HopConnector {
 
 pub(super) struct NextPacketDetails {
 	pub(super) next_packet_pubkey: Result<PublicKey, secp256k1::Error>,
+	pub(super) next_hop_forward_info: Option<NextHopForwardInfo>,
+}
+
+pub(super) struct NextHopForwardInfo {
 	pub(super) outgoing_connector: HopConnector,
 	pub(super) outgoing_amt_msat: u64,
 	pub(super) outgoing_cltv_value: u32,
@@ -591,8 +598,12 @@ where
 			let next_packet_pubkey = onion_utils::next_hop_pubkey(secp_ctx,
 				msg.onion_routing_packet.public_key.unwrap(), &shared_secret.secret_bytes());
 			Some(NextPacketDetails {
-				next_packet_pubkey, outgoing_connector: HopConnector::ShortChannelId(short_channel_id),
-				outgoing_amt_msat: amt_to_forward, outgoing_cltv_value
+				next_packet_pubkey,
+				next_hop_forward_info: Some(NextHopForwardInfo {
+					outgoing_connector: HopConnector::ShortChannelId(short_channel_id),
+					outgoing_amt_msat: amt_to_forward,
+					outgoing_cltv_value,
+				}),
 			})
 		}
 		onion_utils::Hop::BlindedForward { next_hop_data: msgs::InboundOnionBlindedForwardPayload { short_channel_id, ref payment_relay, ref payment_constraints, ref features, .. }, shared_secret, .. } => {
@@ -608,8 +619,12 @@ where
 			let next_packet_pubkey = onion_utils::next_hop_pubkey(&secp_ctx,
 				msg.onion_routing_packet.public_key.unwrap(), &shared_secret.secret_bytes());
 			Some(NextPacketDetails {
-				next_packet_pubkey, outgoing_connector: HopConnector::ShortChannelId(short_channel_id), outgoing_amt_msat: amt_to_forward,
-				outgoing_cltv_value
+				next_packet_pubkey,
+				next_hop_forward_info: Some(NextHopForwardInfo {
+					outgoing_connector: HopConnector::ShortChannelId(short_channel_id),
+					outgoing_amt_msat: amt_to_forward,
+					outgoing_cltv_value,
+				}),
 			})
 		}
 		onion_utils::Hop::TrampolineForward { next_trampoline_hop_data: msgs::InboundTrampolineForwardPayload { amt_to_forward, outgoing_cltv_value, next_trampoline }, trampoline_shared_secret, incoming_trampoline_public_key, .. } => {
@@ -617,10 +632,18 @@ where
 				incoming_trampoline_public_key, &trampoline_shared_secret.secret_bytes());
 			Some(NextPacketDetails {
 				next_packet_pubkey: next_trampoline_packet_pubkey,
-				outgoing_connector: HopConnector::Trampoline(next_trampoline),
-				outgoing_amt_msat: amt_to_forward,
-				outgoing_cltv_value,
+				next_hop_forward_info: Some(NextHopForwardInfo {
+					outgoing_connector: HopConnector::Trampoline(next_trampoline),
+					outgoing_amt_msat: amt_to_forward,
+					outgoing_cltv_value,
+				}),
 			})
+		},
+		onion_utils::Hop::Dummy { shared_secret, .. } => {
+			let next_packet_pubkey = onion_utils::next_hop_pubkey(secp_ctx,
+				msg.onion_routing_packet.public_key.unwrap(), &shared_secret.secret_bytes());
+
+			Some(NextPacketDetails { next_packet_pubkey, next_hop_forward_info: None })
 		}
 		_ => None
 	};

--- a/lightning/src/ln/onion_payment.rs
+++ b/lightning/src/ln/onion_payment.rs
@@ -123,6 +123,14 @@ pub(super) fn create_fwd_pending_htlc_info(
 			(RoutingInfo::Direct { short_channel_id, new_packet_bytes, next_hop_hmac }, amt_to_forward, outgoing_cltv_value, intro_node_blinding_point,
 				next_blinding_override)
 		},
+		onion_utils::Hop::Dummy { .. } => {
+			debug_assert!(false, "Dummy hop should have been peeled earlier");
+			return Err(InboundHTLCErr {
+				msg: "Dummy Hop OnionHopData provided for us as an intermediary node",
+				reason: LocalHTLCFailureReason::InvalidOnionPayload,
+				err_data: Vec::new(),
+			})
+		},
 		onion_utils::Hop::Receive { .. } | onion_utils::Hop::BlindedReceive { .. } =>
 			return Err(InboundHTLCErr {
 				msg: "Final Node OnionHopData provided for us as an intermediary node",
@@ -327,6 +335,14 @@ pub(super) fn create_recv_pending_htlc_info(
 				msg: "Got blinded non final data with an HMAC of 0",
 			})
 		},
+		onion_utils::Hop::Dummy { .. } => {
+			debug_assert!(false, "Dummy hop should have been peeled earlier");
+			return Err(InboundHTLCErr {
+				reason: LocalHTLCFailureReason::InvalidOnionBlinding,
+				err_data: vec![0; 32],
+				msg: "Got blinded non final data with an HMAC of 0",
+			})
+		}
 		onion_utils::Hop::TrampolineForward { .. } | onion_utils::Hop::TrampolineBlindedForward { .. } => {
 			return Err(InboundHTLCErr {
 				reason: LocalHTLCFailureReason::InvalidOnionPayload,

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -2335,6 +2335,12 @@ where
 						new_packet_bytes,
 					})
 				},
+				msgs::InboundOnionPayload::Dummy { intro_node_blinding_point } => Ok(Hop::Dummy {
+					intro_node_blinding_point,
+					shared_secret,
+					next_hop_hmac,
+					new_packet_bytes,
+				}),
 				_ => {
 					if blinding_point.is_some() {
 						return Err(OnionDecodeErr::Malformed {

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -2202,6 +2202,17 @@ pub(crate) enum Hop {
 		/// Bytes of the onion packet we're forwarding.
 		new_packet_bytes: [u8; ONION_DATA_LEN],
 	},
+	/// This onion payload is dummy, and needs to be peeled by us.
+	Dummy {
+		/// Blinding point for introduction-node dummy hops.
+		intro_node_blinding_point: Option<PublicKey>,
+		/// Shared secret for decrypting the next-hop public key.
+		shared_secret: SharedSecret,
+		/// HMAC of the next hop's onion packet.
+		next_hop_hmac: [u8; 32],
+		/// Onion packet bytes after this dummy layer is peeled.
+		new_packet_bytes: [u8; ONION_DATA_LEN],
+	},
 	/// This onion payload was for us, not for forwarding to a next-hop. Contains information for
 	/// verifying the incoming payment.
 	Receive {
@@ -2256,6 +2267,7 @@ impl Hop {
 		match self {
 			Hop::Forward { shared_secret, .. } => shared_secret,
 			Hop::BlindedForward { shared_secret, .. } => shared_secret,
+			Hop::Dummy { shared_secret, .. } => shared_secret,
 			Hop::TrampolineForward { outer_shared_secret, .. } => outer_shared_secret,
 			Hop::TrampolineBlindedForward { outer_shared_secret, .. } => outer_shared_secret,
 			Hop::Receive { shared_secret, .. } => shared_secret,

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -74,6 +74,9 @@ pub struct DefaultRouter<
 	score_params: SP,
 }
 
+/// The number of dummy hops included in [`BlindedPaymentPath`]s created by [`DefaultRouter`].
+pub const DEFAULT_PAYMENT_DUMMY_HOPS: usize = 3;
+
 impl<
 		G: Deref<Target = NetworkGraph<L>>,
 		L: Deref,
@@ -198,9 +201,9 @@ where
 				})
 			})
 			.map(|forward_node| {
-				BlindedPaymentPath::new(
-					&[forward_node], recipient, local_node_receive_key, tlvs.clone(), u64::MAX, MIN_FINAL_CLTV_EXPIRY_DELTA,
-					&*self.entropy_source, secp_ctx
+				BlindedPaymentPath::new_with_dummy_hops(
+					&[forward_node], recipient, DEFAULT_PAYMENT_DUMMY_HOPS, local_node_receive_key, tlvs.clone(), u64::MAX,
+					MIN_FINAL_CLTV_EXPIRY_DELTA, &*self.entropy_source, secp_ctx
 				)
 			})
 			.take(MAX_PAYMENT_PATHS)
@@ -210,9 +213,9 @@ where
 			Ok(paths) if !paths.is_empty() => Ok(paths),
 			_ => {
 				if network_graph.nodes().contains_key(&NodeId::from_pubkey(&recipient)) {
-					BlindedPaymentPath::new(
-						&[], recipient, local_node_receive_key, tlvs, u64::MAX, MIN_FINAL_CLTV_EXPIRY_DELTA, &*self.entropy_source,
-						secp_ctx
+					BlindedPaymentPath::new_with_dummy_hops(
+						&[], recipient, DEFAULT_PAYMENT_DUMMY_HOPS, local_node_receive_key, tlvs, u64::MAX,
+						MIN_FINAL_CLTV_EXPIRY_DELTA, &*self.entropy_source, secp_ctx
 					).map(|path| vec![path])
 				} else {
 					Err(())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blinded payments can include configurable dummy intermediate hops; a public default dummy-hop count is provided.

* **Refactor**
  * Onion payload and forwarding logic treat dummy hops as first-class: dummy hops are peeled exactly once and next-hop forwarding info is propagated explicitly to ensure correct routing and error handling.

* **Tests**
  * Tests and test helpers updated/added to exercise dummy-hop traversal, decoding, and fee/forward-info behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->